### PR TITLE
Fix/albedoless

### DIFF
--- a/core/assets/MaterialAsset.h
+++ b/core/assets/MaterialAsset.h
@@ -13,7 +13,7 @@ namespace core {
 
 // Forward declarations
 class GpuDescriptorSet;
-class GpuInstance;
+class Renderer;
 
 struct MaterialUniform {
   glm::vec4 emissive_factor;
@@ -26,8 +26,12 @@ struct MaterialUniform {
 
   uint32_t is_unlit;
   uint32_t enable_blend;
+  uint32_t has_albedo_texture;
   uint32_t has_emissive_texture;
   uint32_t has_metal_roughness_texture;
+
+  // TODO(marceline-cramer) Use bit array over individual uint32s
+  uint32_t _padding[3];
 };
 
 class MaterialAsset : public Asset {
@@ -35,9 +39,9 @@ class MaterialAsset : public Asset {
   DECL_ASSET_TYPE(assets::AssetType::MaterialAsset);
 
   // Asset lifetime implementation
-  MaterialAsset() : gpu(nullptr) {}
-  MaterialAsset(AssetPool* asset_pool, GpuInstance* gpu)
-      : asset_pool(asset_pool), gpu(gpu) {}
+  MaterialAsset() : renderer(nullptr) {}
+  MaterialAsset(AssetPool* asset_pool, Renderer* renderer)
+      : asset_pool(asset_pool), renderer(renderer) {}
   void load(const assets::SerializedAsset*) final;
 
   // Override isLoaded() to include the textures
@@ -49,7 +53,7 @@ class MaterialAsset : public Asset {
 
  private:
   AssetPool* asset_pool;
-  GpuInstance* gpu;
+  Renderer* renderer;
 
   bool double_sided;
 

--- a/core/renderer/MeshPass.cc
+++ b/core/renderer/MeshPass.cc
@@ -141,7 +141,7 @@ MeshPass::MeshPass(Renderer* renderer, World* world)
     log_zone_named("Initialize asset types");
 
     AssetPool* asset_pool = world->getAssetPool();
-    asset_pool->initializeAssetType<MaterialAsset>(asset_pool, gpu);
+    asset_pool->initializeAssetType<MaterialAsset>(asset_pool, renderer);
     asset_pool->initializeAssetType<MeshAsset>(this);
     asset_pool->initializeAssetType<TextureAsset>(this);
   }

--- a/core/renderer/Renderer.h
+++ b/core/renderer/Renderer.h
@@ -44,6 +44,8 @@ class Renderer {
   uint32_t getDepthSubpass() { return 0; }
   uint32_t getForwardSubpass() { return 1; }
 
+  GpuImage* getErrorImage() { return error_image; }
+
  private:
   const CVarScope* cvars;
   DisplayInterface* display;
@@ -72,6 +74,8 @@ class Renderer {
 
   uint32_t current_frame = 0;
   types::vector<PipelinedFrameData> frames_in_flight;
+
+  GpuImage* error_image = nullptr;
 };
 
 }  // namespace core

--- a/core/shaders/mesh_depth.vert
+++ b/core/shaders/mesh_depth.vert
@@ -21,6 +21,7 @@ struct MaterialUniform {
 
   bool is_unlit;
   bool enable_blend;
+  bool has_albedo_texture;
   bool has_emissive_texture;
   bool has_metal_roughness_texture;
 };

--- a/core/shaders/mesh_forward.frag
+++ b/core/shaders/mesh_forward.frag
@@ -21,6 +21,7 @@ struct MaterialUniform {
 
   bool is_unlit;
   bool enable_blend;
+  bool has_albedo_texture;
   bool has_emissive_texture;
   bool has_metal_roughness_texture;
 };
@@ -149,8 +150,10 @@ vec3 getNormal(in MaterialUniform material) {
 vec3 getAlbedo(in MaterialUniform material) {
   vec3 surface_albedo = material.albedo_factor.rgb;
 
-  vec4 sampled_albedo = texture(albedo_texture, fragTexCoord);
-  surface_albedo *= sampled_albedo.rgb;
+  if (material.has_albedo_texture) {
+    vec4 sampled_albedo = texture(albedo_texture, fragTexCoord);
+    surface_albedo *= sampled_albedo.rgb;
+  }
 
   return surface_albedo;
 }


### PR DESCRIPTION
The core would crash when it tried to load a `MaterialAsset` that didn't have an albedo (or base color) texture, so I added an "error image" to `Renderer` that `MaterialAsset` could then use as a stand-in for missing textures, instead of trying to plug in a missing albedo texture.