### PR TITLE
Fix server spinlock

### DIFF
--- a/core/network/NetworkServer.cc
+++ b/core/network/NetworkServer.cc
@@ -91,6 +91,8 @@ NetworkServer::~NetworkServer() {
 }
 
 void NetworkServer::updateWorld() {
+  log_zone;
+
   sendWorldUpdates();
   world_event_sorter->clearQueue();
 }

--- a/server/server_main.cc
+++ b/server/server_main.cc
@@ -5,6 +5,7 @@
 #include <csignal>
 #include <iostream>
 #include <memory>
+#include <thread>
 
 #include "CLI/App.hpp"
 #include "CLI/Config.hpp"


### PR DESCRIPTION
`server_main` was unnecessarily spinlocking to lock the maximum ticks per second, so this PR replaces the spinlock with a delay function. This reduces the server CPU usage from %100 to %0.7!