### PR TITLE
Run CI only on main branch

### DIFF
--- a/.github/workflows/build_check.yaml
+++ b/.github/workflows/build_check.yaml
@@ -3,7 +3,13 @@
 
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/style_check.yaml
+++ b/.github/workflows/style_check.yaml
@@ -3,7 +3,13 @@
 
 name: Code Style Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   cpplint-check:


### PR DESCRIPTION
This halves CI time, which also halves self-hosted cloud costs.