### PR TITLE
fix toml submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,6 @@
 	path = vcpkg
 	url = https://github.com/Microsoft/vcpkg.git
 
-[submodule "bindings/toml"]
+[submodule "toml"]
 	path = codegen/toml
 	url = https://github.com/uiri/toml.git


### PR DESCRIPTION
re-added the toml git submodule (which somehow broke across the bindings/ => codegen/ rename earlier)

Hello! Thank you for opening a pull request. Before we can merge your changes,
we need to make sure that your pull request:

- [-] Removes solved to-dos
- [-] Updates in-repo documentation
- [-] Adds to-dos for future PRs
