### PR TITLE
Fix/gpu transfer size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ docs/_site/
 **.h.gch
 **/__pycache__/
 **.pyc
+
+.vs/
+out/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@ The following GitHub users have contributed source code to Mondradiko:
 - @marceline-cramer
 - @Turtle1331
 - @humbletim
+- @This-Is-Alex

--- a/core/renderer/Renderer.cc
+++ b/core/renderer/Renderer.cc
@@ -287,7 +287,7 @@ void Renderer::transferDataToBuffer(GpuBuffer* dst, size_t offset,
     log_ftl("Failed to allocate Vulkan buffer.");
   }
 
-  memcpy(allocation_info.pMappedData, src, allocation_info.size);
+  memcpy(allocation_info.pMappedData, src, size);
 
   VkCommandBuffer command_buffer = gpu->beginSingleTimeCommands();
   VkBufferCopy buffer_copy{};
@@ -331,7 +331,7 @@ void Renderer::transferDataToImage(GpuImage* dst, const void* src) {
     log_ftl("Failed to allocate Vulkan buffer");
   }
 
-  memcpy(allocation_info.pMappedData, src, allocation_info.size);
+  memcpy(allocation_info.pMappedData, src, size);
 
   VkCommandBuffer commandBuffer = gpu->beginSingleTimeCommands();
 


### PR DESCRIPTION
`memcpy` command now gets the size from GpuImage rather than VmaAllocation, which gives a different result for the size (on Windows at least)

Following guidance from @marceline-cramer