### PR TITLE
Fix/script asset

### DIFF
--- a/converter/script/WasmConverter.cc
+++ b/converter/script/WasmConverter.cc
@@ -11,7 +11,7 @@ namespace converter {
 
 WasmConverter::AssetOffset WasmConverter::convert(
     AssetBuilder* fbb, std::filesystem::path wasm_path) const {
-  std::ifstream script_file(wasm_path);
+  std::ifstream script_file(wasm_path, std::ifstream::binary);
 
   script_file.seekg(0, std::ios::end);
   std::streampos length = script_file.tellg();

--- a/converter/script/WasmConverter.cc
+++ b/converter/script/WasmConverter.cc
@@ -6,12 +6,18 @@
 #include <fstream>
 #include <vector>
 
+#include "log/log.h"
+
 namespace mondradiko {
 namespace converter {
 
 WasmConverter::AssetOffset WasmConverter::convert(
     AssetBuilder* fbb, std::filesystem::path wasm_path) const {
   std::ifstream script_file(wasm_path, std::ifstream::binary);
+
+  if (!script_file) {
+    log_ftl_fmt("Failed to open %s", wasm_path.c_str());
+  }
 
   script_file.seekg(0, std::ios::end);
   std::streampos length = script_file.tellg();


### PR DESCRIPTION
Fixes an issue @This-Is-Alex was having with script loading, where the `ScriptAsset` text data was getting contaminated with null terminators. This was solved by loading the `wat` source file in binary mode.