### PR TITLE
Upgrade/script objects

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -65,7 +65,7 @@ add_subdirectory(components)
 add_subdirectory(ui)
 
 set(COMPONENT_CLASSDEFS
-  components/Transform.toml
+  components/TransformComponent.toml
 )
 
 set(UI_CLASSDEFS

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -76,6 +76,8 @@ set(UI_CLASSDEFS
 wrap_classes(SCRIPT_LINKERS "wasm-linker" "${COMPONENT_CLASSDEFS};${UI_CLASSDEFS}")
 wrap_classes(AS_BINDINGS "as-binding" "${COMPONENT_CLASSDEFS};${UI_CLASSDEFS}")
 
+file(COPY components/Entity.d.ts DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/components)
+
 if (NOT WIN32)
   add_library(mondradiko-as-bindings INTERFACE ${AS_BINDINGS})
   set_target_properties(mondradiko-as-bindings PROPERTIES FOLDER "components")

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(components)
 add_subdirectory(ui)
 
 set(COMPONENT_CLASSDEFS
+  components/PointLightComponent.toml
   components/TransformComponent.toml
 )
 

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -67,6 +67,7 @@ add_subdirectory(ui)
 set(COMPONENT_CLASSDEFS
   components/PointLightComponent.toml
   components/TransformComponent.toml
+  components/World.toml
 )
 
 set(UI_CLASSDEFS

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -9,7 +9,7 @@ Each object that is handled by codegen is first defined in a "classdef" file,
 following the TOML format. Here's an example of a classdef file:
 
 ```toml
-name = "Transform"
+name = "TransformComponent"
 storage_type = "component"
 internal_name = "TransformComponent"
 internal_header = "core/components/TransformComponent.h"
@@ -33,9 +33,9 @@ internal_header = "core/components/TransformComponent.h"
   params = ["double", "double", "double"]
 ```
 
-The class being defined here is named "Transform," and this classdef gives it
-several methods, of which each can have a description, list of parameters, and
-list of return values.
+The class being defined here is named "TransformComponent," and this classdef
+gives it several methods, of which each can have a description, list of
+parameters, and list of return values.
 
 This classdef file is then consumed by the codegen implementation to generate
 various source files. For example, `wasm_linker.py` creates a C++ source file
@@ -54,6 +54,7 @@ The outwards-facing name of this classdef.
 Either:
 
 - `dynamic_object`: IDs are keys into the script registry
+- `static_object`: No IDs, and methods operate on a singleton object
 - `component`: IDs are entity IDs, and this classdef is a component
 
 ### Internal Name
@@ -86,7 +87,6 @@ Contains the classdefs for the component scripting API.
 
 # To-Do
 
-- Scriptable object base classes
 - World component synchronization
 - World update event factory implementation
 - Generate separate documentation for the API

--- a/codegen/as_binding.py
+++ b/codegen/as_binding.py
@@ -51,9 +51,16 @@ class AsBinding(Codegen):
             f"{param_name}: {type_name}"
             for param_name, type_name in params])
 
+        attributes = []
+
+        if self.storage_type == "static_object":
+            attributes.append("static")
+
+        attributes = " ".join(attributes)
+
         self.out.extend([
             f"  @external(\"{self.internal_name}_{method_name}\")",
-            f"  {method_name}({param_list}): {return_type}",
+            f"  {attributes} {method_name}({param_list}): {return_type}",
             ""
         ])
 

--- a/codegen/components/Entity.d.ts
+++ b/codegen/components/Entity.d.ts
@@ -1,0 +1,20 @@
+// Mondradiko scripting API - AssemblyScript bindings
+// https://mondradiko.github.io/
+
+import TransformComponent from "./TransformComponent";
+
+@unmanaged declare class Entity {
+  @external("Entity_getComponent")
+  get<T>(): T
+
+  /////////////////////
+  // TransformComponent
+  /////////////////////
+  @external("Entity_hasTransform")
+  hasTransform(): bool
+
+  @external("Entity_addTransform")
+  addTransform(): TransformComponent
+}
+
+export default Entity;

--- a/codegen/components/Entity.d.ts
+++ b/codegen/components/Entity.d.ts
@@ -1,11 +1,21 @@
 // Mondradiko scripting API - AssemblyScript bindings
 // https://mondradiko.github.io/
 
+import PointLightComponent from "./PointLightComponent";
 import TransformComponent from "./TransformComponent";
 
 @unmanaged declare class Entity {
   @external("Entity_getComponent")
   get<T>(): T
+
+  /////////////////////
+  // PointLightComponent
+  /////////////////////
+  @external("Entity_hasPointLight")
+  hasPointLight(): bool
+
+  @external("Entity_addPointLight")
+  addPointLight(): PointLightComponent
 
   /////////////////////
   // TransformComponent

--- a/codegen/components/PointLightComponent.toml
+++ b/codegen/components/PointLightComponent.toml
@@ -1,0 +1,17 @@
+# Copyright (c) 2020-2021 the Mondradiko contributors.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+name = "PointLightComponent"
+storage_type = "component"
+internal_name = "PointLightComponent"
+internal_header = "core/components/PointLightComponent.h"
+
+[methods]
+
+  [methods.setIntensity]
+  param_list = ["r", "g", "b"]
+
+    [methods.setIntensity.params]
+    r = "double"
+    g = "double"
+    b = "double"

--- a/codegen/components/TransformComponent.toml
+++ b/codegen/components/TransformComponent.toml
@@ -9,19 +9,19 @@ internal_header = "core/components/TransformComponent.h"
 [methods]
 
   [methods.getX]
-  brief = "Retrieves the X coordinate of this TransformComponent."
+  brief = "Retrieves the X coordinate."
   return = "double"
 
   [methods.getY]
-  brief = "Retrieves the Y coordinate of this TransformComponent."
+  brief = "Retrieves the Y coordinate."
   return = "double"
 
   [methods.getZ]
-  brief = "Retrieves the Z coordinate of this TransformComponent."
+  brief = "Retrieves the Z coordinate."
   return = "double"
 
   [methods.setPosition]
-  brief = "Sets the position of this TransformComponent."
+  brief = "Sets the position."
   param_list = ["x", "y", "z"]
 
     [methods.setPosition.params]
@@ -30,23 +30,23 @@ internal_header = "core/components/TransformComponent.h"
     z = "double"
 
   [methods.getRotationW]
-  brief = "Retrieves the W rotation component of this Transform's Quarternion."
+  brief = "Retrieves the W rotation component."
   return = "double"
 
   [methods.getRotationX]
-  brief = "Retrieves the X rotation component of this Transform's Quarternion."
+  brief = "Retrieves the X rotation component."
   return = "double"
 
   [methods.getRotationY]
-  brief = "Retrieves the Y rotation component of this Transform's Quarternion."
+  brief = "Retrieves the Y rotation component."
   return = "double"
 
   [methods.getRotationZ]
-  brief = "Retrieves the Z rotation component of this Transform's Quarternion."
+  brief = "Retrieves the Z rotation component."
   return = "double"
-  
+
   [methods.setRotation]
-  brief = "Sets the Quarternion rotation of this Transform."
+  brief = "Sets the quaternion rotation."
   param_list = ["w", "x", "y", "z"]
 
     [methods.setRotation.params]

--- a/codegen/components/TransformComponent.toml
+++ b/codegen/components/TransformComponent.toml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2021 the Mondradiko contributors.
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-name = "Transform"
+name = "TransformComponent"
 storage_type = "component"
 internal_name = "TransformComponent"
 internal_header = "core/components/TransformComponent.h"
@@ -9,19 +9,19 @@ internal_header = "core/components/TransformComponent.h"
 [methods]
 
   [methods.getX]
-  brief = "Retrieves the X coordinate of this Transform."
+  brief = "Retrieves the X coordinate of this TransformComponent."
   return = "double"
 
   [methods.getY]
-  brief = "Retrieves the Y coordinate of this Transform."
+  brief = "Retrieves the Y coordinate of this TransformComponent."
   return = "double"
 
   [methods.getZ]
-  brief = "Retrieves the Z coordinate of this Transform."
+  brief = "Retrieves the Z coordinate of this TransformComponent."
   return = "double"
 
   [methods.setPosition]
-  brief = "Sets the position of this Transform."
+  brief = "Sets the position of this TransformComponent."
   param_list = ["x", "y", "z"]
 
     [methods.setPosition.params]

--- a/codegen/components/World.toml
+++ b/codegen/components/World.toml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020-2021 the Mondradiko contributors.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+name = "World"
+storage_type = "static_object"
+internal_name = "World"
+internal_header = "core/world/World.h"
+dependencies = ["Entity"]
+
+[methods]
+
+  [methods.spawnEntity]
+  return_class = "Entity"
+
+  [methods.spawnEntityAt]
+  param_list = ["x", "y", "z"]
+  return_class = "Entity"
+
+    [methods.spawnEntityAt.params]
+    x = "double"
+    y = "double"
+    z = "double"

--- a/codegen/linker_common.h
+++ b/codegen/linker_common.h
@@ -18,9 +18,13 @@ namespace codegen {
 using namespace core;
 
 template <class ClassdefType>
-using BoundClassdefMethod = wasm_trap_t* (ClassdefType::*)(ScriptEnvironment*,
-                                                           const wasm_val_t[],
+using BoundClassdefMethod = wasm_trap_t* (ClassdefType::*)(const wasm_val_t[],
                                                            wasm_val_t[]);
+
+template <class ClassdefType>
+using BoundComponentMethod = wasm_trap_t* (ClassdefType::*)(ScriptEnvironment*,
+                                                            const wasm_val_t[],
+                                                            wasm_val_t[]);
 
 using ClassdefMethodCallback = const wasm_functype_t* (*)();
 
@@ -30,7 +34,7 @@ static const wasm_functype_t* createClassdefMethodType();
 
 static void finalizer(void*) {}
 
-template <class ComponentType, BoundClassdefMethod<ComponentType> method>
+template <class ComponentType, BoundComponentMethod<ComponentType> method>
 static wasm_trap_t* componentMethodWrapper(const wasmtime_caller_t* caller,
                                            void* env, const wasm_val_t args[],
                                            wasm_val_t results[]) {
@@ -53,7 +57,7 @@ static wasm_trap_t* componentMethodWrapper(const wasmtime_caller_t* caller,
   return ((*self).*method)(world->scripts, args, results);
 }
 
-template <class ComponentType, BoundClassdefMethod<ComponentType> method>
+template <class ComponentType, BoundComponentMethod<ComponentType> method>
 void linkComponentMethod(ScriptEnvironment* scripts, World* world,
                          const char* symbol,
                          ClassdefMethodCallback type_callback) {
@@ -108,7 +112,7 @@ static wasm_trap_t* dynamicObjectMethodWrapper(const wasmtime_caller_t* caller,
     return wasm_trap_new(scripts->getStore(), &error);
   }*/
 
-  return ((*self).*method)(scripts, args, results);
+  return ((*self).*method)(args, results);
 }
 
 template <class ObjectType, BoundClassdefMethod<ObjectType> method>

--- a/codegen/linker_common.h
+++ b/codegen/linker_common.h
@@ -47,11 +47,7 @@ static wasm_trap_t* componentMethodWrapper(const wasmtime_caller_t* caller,
     error_format << "Type assertion failed: ";
     error_format << "Entity " << self_id << " does not have a ";
     error_format << typeid(ComponentType).name();
-
-    wasm_name_t error;
-    wasm_name_new_from_string(&error, error_format.str().c_str());
-
-    return wasm_trap_new(world->scripts->getStore(), &error);
+    return world->scripts->createTrap(error_format.str());
   }
 
   return ((*self).*method)(world->scripts, args, results);
@@ -90,11 +86,7 @@ static wasm_trap_t* dynamicObjectMethodWrapper(const wasmtime_caller_t* caller,
     std::ostringstream error_format;
     error_format << "Registry lookup failed: ";
     error_format << self_id << " is an invalid ID";
-
-    wasm_name_t error;
-    wasm_name_new_from_string(&error, error_format.str().c_str());
-
-    return wasm_trap_new(scripts->getStore(), &error);
+    return scripts->createTrap(error_format.str());
   }
 
   ObjectType* self = reinterpret_cast<ObjectType*>(self_raw);

--- a/codegen/wasm_linker.py
+++ b/codegen/wasm_linker.py
@@ -4,7 +4,13 @@
 from codegen import Codegen, preamble
 
 
-LINKER_LINK_FORMAT = "template<> void core::ScriptObject<core::{0}>::linkScriptApi(ScriptEnvironment* scripts, World* world)"
+COMPONENT_LINK_FORMAT = "template<> void core::ScriptableComponent<core::{0}, core::{0}::SerializedType>::linkScriptApi(ScriptEnvironment* scripts, World* world)"
+
+
+DYNAMIC_LINK_FORMAT = "template<> void core::DynamicScriptObject<core::{0}>::linkScriptApi(ScriptEnvironment* scripts)"
+
+
+STATIC_LINK_FORMAT = "template<> void core::StaticScriptObject<core::{0}>::linkScriptApi(ScriptEnvironment* scripts, {0}* self)"
 
 
 METHOD_TYPE_FORMAT = "const wasm_functype_t* methodType_{0}_{1}()"
@@ -78,8 +84,10 @@ class WasmLinker(Codegen):
             ""])
 
         if self.storage_type == "component":
+            self.link_format = COMPONENT_LINK_FORMAT
             self.method_wrap = COMPONENT_METHOD_WRAP
         elif self.storage_type == "dynamic_object":
+            self.link_format = DYNAMIC_LINK_FORMAT
             self.method_wrap = DYNAMIC_OBJECT_METHOD_WRAP
         else:
             raise ValueError("Invalid storage_type: " + self.storage_type)
@@ -137,7 +145,7 @@ class WasmLinker(Codegen):
 
         # Implement Component::linkScriptApi()
         self.out.extend([
-            LINKER_LINK_FORMAT.format(self.internal_name),
+            self.link_format.format(self.internal_name),
             "{"])
 
         self.out.extend(f"  {method}" for method in self.methods)

--- a/codegen/wasm_linker.py
+++ b/codegen/wasm_linker.py
@@ -24,6 +24,10 @@ DYNAMIC_OBJECT_METHOD_WRAP = \
     "codegen::linkDynamicObjectMethod<{1}, &{1}::{2}>(scripts, \"{1}_{2}\", codegen::methodType_{0}_{2});"
 
 
+STATIC_OBJECT_METHOD_WRAP = \
+    "codegen::linkStaticObjectMethod<{1}, &{1}::{2}>(scripts, self, \"{1}_{2}\", codegen::methodType_{0}_{2});"
+
+
 C_TYPES_TO_WASM = {
     "self": "WASM_I32",
     "double": "WASM_F64"
@@ -89,6 +93,9 @@ class WasmLinker(Codegen):
         elif self.storage_type == "dynamic_object":
             self.link_format = DYNAMIC_LINK_FORMAT
             self.method_wrap = DYNAMIC_OBJECT_METHOD_WRAP
+        elif self.storage_type == "static_object":
+            self.link_format = STATIC_LINK_FORMAT
+            self.method_wrap = STATIC_OBJECT_METHOD_WRAP
         else:
             raise ValueError("Invalid storage_type: " + self.storage_type)
 
@@ -102,7 +109,11 @@ class WasmLinker(Codegen):
             "{"])
 
         # Parse parameters
-        params = ["self"]
+        if self.storage_type != "static_object":
+            params = ["self"]
+        else:
+            params = []
+
         if "param_list" in method.keys():
             params.extend([
                 method["params"][param] for param in method["param_list"]])

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,6 +69,7 @@ set(MONDRADIKO_CORE_SRC
   ui/GlyphStyle.cc
   ui/UiPanel.cc
   ui/UserInterface.cc
+  world/ScriptEntity.cc
   world/World.cc
   world/WorldEventSorter.cc
 )

--- a/core/components/Component.h
+++ b/core/components/Component.h
@@ -26,14 +26,15 @@ void buildUpdateComponents(
     flatbuffers::Offset<flatbuffers::Vector<const ProtocolComponentType*>>);
 
 template <typename DataType>
-class Component {
+class SynchronizedComponent {
  public:
   // Make data type public so other classes can use it
   using SerializedType = DataType;
 
-  Component() {}
-  explicit Component(const SerializedType& data) : _data(data) {}
+  SynchronizedComponent() {}
+  explicit SynchronizedComponent(const SerializedType& data) : _data(data) {}
 
+  // TODO(marceline-cramer) CRTP this method
   virtual void refresh(AssetPool*) {}
 
   void markDirty() { dirty = true; }
@@ -48,6 +49,17 @@ class Component {
 
  private:
   bool dirty = true;
+};
+
+template <typename Inheritor, typename DataType>
+class ScriptableComponent : public SynchronizedComponent<DataType> {
+ public:
+  ScriptableComponent() {}
+  explicit ScriptableComponent(const DataType& data)
+      : SynchronizedComponent<DataType>(data) {}
+
+  // Defined in generated API linker
+  static void linkScriptApi(ScriptEnvironment*, World*);
 };
 
 }  // namespace core

--- a/core/components/MeshRendererComponent.h
+++ b/core/components/MeshRendererComponent.h
@@ -13,10 +13,10 @@ namespace mondradiko {
 namespace core {
 
 class MeshRendererComponent
-    : public Component<protocol::MeshRendererComponent> {
+    : public SynchronizedComponent<protocol::MeshRendererComponent> {
  public:
   explicit MeshRendererComponent(const protocol::MeshRendererComponent& data)
-      : Component(data) {}
+      : SynchronizedComponent(data) {}
 
   explicit MeshRendererComponent(const assets::MeshRendererPrefab* prefab) {
     _data.mutate_mesh_asset(static_cast<protocol::AssetId>(prefab->mesh()));
@@ -25,7 +25,7 @@ class MeshRendererComponent
   }
 
   MeshRendererComponent(AssetId mesh_asset, AssetId material_asset)
-      : Component(protocol::MeshRendererComponent(
+      : SynchronizedComponent(protocol::MeshRendererComponent(
             static_cast<protocol::AssetId>(mesh_asset),
             static_cast<protocol::AssetId>(material_asset))) {}
 

--- a/core/components/PointLightComponent.cc
+++ b/core/components/PointLightComponent.cc
@@ -20,6 +20,15 @@ void PointLightComponent::getUniform(PointLightUniform* uniform) {
   uniform->intensity.b = _data.intensity().z();
 }
 
+wasm_trap_t* PointLightComponent::setIntensity(ScriptEnvironment*,
+                                               const wasm_val_t args[],
+                                               wasm_val_t[]) {
+  _data.mutable_intensity().mutate_x(args[1].of.f64);
+  _data.mutable_intensity().mutate_y(args[2].of.f64);
+  _data.mutable_intensity().mutate_z(args[3].of.f64);
+  return nullptr;
+}
+
 // Template specialization to build UpdateComponents event
 template <>
 void buildUpdateComponents<mondradiko::protocol::PointLightComponent>(

--- a/core/components/PointLightComponent.h
+++ b/core/components/PointLightComponent.h
@@ -16,10 +16,11 @@ struct PointLightUniform {
   glm::vec4 intensity;
 };
 
-class PointLightComponent : public Component<protocol::PointLightComponent> {
+class PointLightComponent
+    : public SynchronizedComponent<protocol::PointLightComponent> {
  public:
   explicit PointLightComponent(const protocol::PointLightComponent& data)
-      : Component(data) {}
+      : SynchronizedComponent(data) {}
 
   explicit PointLightComponent(const assets::PointLightPrefab* prefab) {
     // TODO(marceline-cramer) Make helpers for these

--- a/core/components/PointLightComponent.h
+++ b/core/components/PointLightComponent.h
@@ -5,6 +5,7 @@
 
 #include "core/components/Component.h"
 #include "lib/include/glm_headers.h"
+#include "lib/include/wasm_headers.h"
 #include "types/assets/PrefabAsset_generated.h"
 #include "types/protocol/PointLightComponent_generated.h"
 
@@ -17,10 +18,11 @@ struct PointLightUniform {
 };
 
 class PointLightComponent
-    : public SynchronizedComponent<protocol::PointLightComponent> {
+    : public ScriptableComponent<PointLightComponent,
+                                 protocol::PointLightComponent> {
  public:
   explicit PointLightComponent(const protocol::PointLightComponent& data)
-      : SynchronizedComponent(data) {}
+      : ScriptableComponent(data) {}
 
   explicit PointLightComponent(const assets::PointLightPrefab* prefab) {
     // TODO(marceline-cramer) Make helpers for these
@@ -47,7 +49,15 @@ class PointLightComponent
     _data.mutable_intensity().mutate_z(b);
   }
 
+  PointLightComponent() : PointLightComponent(0.0, 0.0, 0.0, 1.0, 0.0, 0.0) {}
+
   void getUniform(PointLightUniform*);
+
+  //
+  // Script methods
+  //
+  wasm_trap_t* setIntensity(ScriptEnvironment*, const wasm_val_t[],
+                            wasm_val_t[]);
 
  private:
 };

--- a/core/components/RelationshipComponent.h
+++ b/core/components/RelationshipComponent.h
@@ -11,10 +11,10 @@ namespace mondradiko {
 namespace core {
 
 class RelationshipComponent
-    : public Component<protocol::RelationshipComponent> {
+    : public SynchronizedComponent<protocol::RelationshipComponent> {
  public:
   explicit RelationshipComponent(const protocol::RelationshipComponent& data)
-      : Component(data) {}
+      : SynchronizedComponent(data) {}
 
   explicit RelationshipComponent(EntityId);
 

--- a/core/components/RigidBodyComponent.h
+++ b/core/components/RigidBodyComponent.h
@@ -14,7 +14,8 @@ namespace core {
 // Forward declarations
 class TransformComponent;
 
-class RigidBodyComponent : public Component<protocol::RigidBodyComponent> {
+class RigidBodyComponent
+    : public SynchronizedComponent<protocol::RigidBodyComponent> {
  public:
   explicit RigidBodyComponent(const assets::RigidBodyPrefab*);
   ~RigidBodyComponent();

--- a/core/components/TransformComponent.h
+++ b/core/components/TransformComponent.h
@@ -53,6 +53,9 @@ class TransformComponent
     _orientation.mutate_z(orientation.z);
   }
 
+  TransformComponent()
+      : TransformComponent(glm::vec3(0.0, 0.0, 0.0), glm::quat()) {}
+
   glm::mat4 getWorldTransform() const { return world_transform; }
 
   //

--- a/core/components/TransformComponent.h
+++ b/core/components/TransformComponent.h
@@ -16,11 +16,12 @@ namespace core {
 // Forward declarations
 class ScriptEnvironment;
 
-class TransformComponent : public Component<protocol::TransformComponent>,
-                           public ScriptObject<TransformComponent> {
+class TransformComponent
+    : public ScriptableComponent<TransformComponent,
+                                 protocol::TransformComponent> {
  public:
   explicit TransformComponent(const protocol::TransformComponent& data)
-      : Component(data) {}
+      : ScriptableComponent(data) {}
 
   explicit TransformComponent(const assets::TransformPrefab* prefab) {
     // TODO(marceline-cramer) Make helpers for these

--- a/core/scripting/ScriptEnvironment.cc
+++ b/core/scripting/ScriptEnvironment.cc
@@ -10,6 +10,7 @@
 #include "core/scripting/ScriptInstance.h"
 #include "core/ui/GlyphStyle.h"
 #include "core/ui/UiPanel.h"
+#include "core/world/ScriptEntity.h"
 #include "log/log.h"
 
 namespace mondradiko {
@@ -123,6 +124,7 @@ void linkComponentApi(ScriptEnvironment* scripts, World* world) {
 
 void ScriptEnvironment::linkComponentApis(World* world) {
   linkComponentApi<TransformComponent>(this, world);
+  linkComponentApi<ScriptEntity>(this, world);
 }
 
 void ScriptEnvironment::linkAssemblyScriptEnv() {

--- a/core/scripting/ScriptEnvironment.cc
+++ b/core/scripting/ScriptEnvironment.cc
@@ -162,6 +162,12 @@ void ScriptEnvironment::update(EntityRegistry* registry, AssetPool* asset_pool,
   }
 }
 
+wasm_trap_t* ScriptEnvironment::createTrap(const types::string& message) {
+  wasm_name_t error;
+  wasm_name_new_from_string(&error, message.c_str());
+  return wasm_trap_new(getStore(), &error);
+}
+
 wasm_module_t* ScriptEnvironment::loadBinaryModule(
     const wasm_byte_vec_t& module_data) {
   wasmtime_error_t* module_error;

--- a/core/scripting/ScriptEnvironment.cc
+++ b/core/scripting/ScriptEnvironment.cc
@@ -4,6 +4,7 @@
 #include "core/scripting/ScriptEnvironment.h"
 
 #include "core/assets/ScriptAsset.h"
+#include "core/components/PointLightComponent.h"
 #include "core/components/ScriptComponent.h"
 #include "core/components/TransformComponent.h"
 #include "core/scripting/ComponentScript.h"
@@ -123,6 +124,7 @@ void linkComponentApi(ScriptEnvironment* scripts, World* world) {
 }
 
 void ScriptEnvironment::linkComponentApis(World* world) {
+  linkComponentApi<PointLightComponent>(this, world);
   linkComponentApi<TransformComponent>(this, world);
   linkComponentApi<ScriptEntity>(this, world);
 }

--- a/core/scripting/ScriptEnvironment.cc
+++ b/core/scripting/ScriptEnvironment.cc
@@ -107,7 +107,7 @@ void ScriptEnvironment::initializeAssets(AssetPool* asset_pool) {
 template <class ObjectType>
 void linkDynamicObjectApi(ScriptEnvironment* scripts) {
   // TODO(marceline-cramer) Don't pass World to dynamic object linkers
-  ObjectType::linkScriptApi(scripts, nullptr);
+  ObjectType::linkScriptApi(scripts);
 }
 
 void ScriptEnvironment::linkUiApis(UserInterface* ui) {

--- a/core/scripting/ScriptEnvironment.h
+++ b/core/scripting/ScriptEnvironment.h
@@ -103,6 +103,28 @@ class ScriptEnvironment {
   void removeFromRegistry(uint32_t);
 
   /**
+   * @brief Stores a static script object.
+   * @param object_key The symbol of the static object.
+   * @param object_ptr The raw pointer to the object.
+   * @return False if the object symbol has already been stored, otherwise true.
+   */
+  bool storeStaticObject(const char*, void*);
+
+  /**
+   * @brief Retrieves a static object.
+   * @param object_key The symbol of the static object to be retrieved.
+   * @return A raw pointer to the object, or nullptr if the key was invalid.
+   */
+  void* getStaticObject(const char*);
+
+  /**
+   * @brief Removes a static object instance, while keeping bindings.
+   * @note storeStaticObject() will still return false after removal.
+   * @param object_key The symbol of the static object to be removed.
+   */
+  void removeStaticObject(const char*);
+
+  /**
    * @brief Updates a local script. Overwrites existing script data, or
    * instantiates a new script if necessary.
    * @param registry The World's registry.
@@ -157,6 +179,7 @@ class ScriptEnvironment {
   wasmtime_interrupt_handle_t* interrupt_handle = nullptr;
 
   types::vector<void*> object_registry;
+  types::unordered_map<types::string, void*> static_objects;
   types::unordered_map<types::string, wasm_func_t*> bindings;
   wasm_func_t* interrupt_func = nullptr;
 };

--- a/core/scripting/ScriptEnvironment.h
+++ b/core/scripting/ScriptEnvironment.h
@@ -32,6 +32,13 @@ class ScriptEnvironment {
   wasmtime_interrupt_handle_t* getInterruptHandle() { return interrupt_handle; }
 
   /**
+   * @brief Creates a WebAssembly trap with a message.
+   * @param message The message for the trap.
+   * @return A handle to the new trap.
+   */
+  wasm_trap_t* createTrap(const types::string&);
+
+  /**
    * @brief Compiles a Wasm module from binary format.
    * @param module_data The Wasm binary data to compile.
    * @return A new wasm_module_t handle.

--- a/core/scripting/ScriptObject.h
+++ b/core/scripting/ScriptObject.h
@@ -26,9 +26,10 @@ class DynamicScriptObject : public ScriptObject<T> {
 
   uint32_t getObjectKey() { return _object_id; }
 
- private:
-  ScriptEnvironment* scripts;
+ protected:
+  ScriptEnvironment* const scripts;
 
+ private:
   uint32_t _object_id;
 };
 

--- a/core/scripting/ScriptObject.h
+++ b/core/scripting/ScriptObject.h
@@ -9,15 +9,11 @@ namespace mondradiko {
 namespace core {
 
 template <class T>
-class ScriptObject {
+class DynamicScriptObject {
  public:
   // Defined in generated API linker
-  static void linkScriptApi(ScriptEnvironment*, World*);
-};
+  static void linkScriptApi(ScriptEnvironment*);
 
-template <class T>
-class DynamicScriptObject : public ScriptObject<T> {
- public:
   explicit DynamicScriptObject(ScriptEnvironment* scripts) : scripts(scripts) {
     _object_id = scripts->storeInRegistry(this);
   }

--- a/core/scripting/ScriptObject.h
+++ b/core/scripting/ScriptObject.h
@@ -29,5 +29,27 @@ class DynamicScriptObject {
   uint32_t _object_id;
 };
 
+template <class T>
+class StaticScriptObject {
+ public:
+  // Defined in generated API linker
+  static void linkScriptApi(ScriptEnvironment*, T*);
+
+  explicit StaticScriptObject(ScriptEnvironment* scripts, const char* symbol)
+      : scripts(scripts), _static_symbol(symbol) {
+    if (scripts->storeStaticObject(_static_symbol, this)) {
+      linkScriptApi(scripts, static_cast<T*>(this));
+    }
+  }
+
+  ~StaticScriptObject() { scripts->removeStaticObject(_static_symbol); }
+
+ protected:
+  ScriptEnvironment* const scripts;
+
+ private:
+  const char* _static_symbol;
+};
+
 }  // namespace core
 }  // namespace mondradiko

--- a/core/ui/GlyphStyle.cc
+++ b/core/ui/GlyphStyle.cc
@@ -62,23 +62,20 @@ GlyphStyleUniform GlyphStyle::getUniform() const {
   return ubo;
 }
 
-wasm_trap_t* GlyphStyle::setOffset(ScriptEnvironment*, const wasm_val_t args[],
-                                   wasm_val_t[]) {
+wasm_trap_t* GlyphStyle::setOffset(const wasm_val_t args[], wasm_val_t[]) {
   _offset.x = args[1].of.f64;
   _offset.y = args[2].of.f64;
 
   return nullptr;
 }
 
-wasm_trap_t* GlyphStyle::setScale(ScriptEnvironment*, const wasm_val_t args[],
-                                  wasm_val_t[]) {
+wasm_trap_t* GlyphStyle::setScale(const wasm_val_t args[], wasm_val_t[]) {
   _scale = args[1].of.f64;
 
   return nullptr;
 }
 
-wasm_trap_t* GlyphStyle::setColor(ScriptEnvironment*, const wasm_val_t args[],
-                                  wasm_val_t[]) {
+wasm_trap_t* GlyphStyle::setColor(const wasm_val_t args[], wasm_val_t[]) {
   _color.r = args[1].of.f64;
   _color.g = args[2].of.f64;
   _color.b = args[3].of.f64;

--- a/core/ui/GlyphStyle.h
+++ b/core/ui/GlyphStyle.h
@@ -36,9 +36,9 @@ class GlyphStyle : public DynamicScriptObject<GlyphStyle> {
   //
   // Scripting methods
   //
-  wasm_trap_t* setOffset(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* setScale(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* setColor(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* setOffset(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* setScale(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* setColor(const wasm_val_t[], wasm_val_t[]);
 
  private:
   GlyphLoader* glyphs;

--- a/core/ui/UiPanel.cc
+++ b/core/ui/UiPanel.cc
@@ -46,29 +46,25 @@ void UiPanel::writeUniform(PanelUniform* panel_uniform) {
   panel_uniform->color = _color;
 }
 
-wasm_trap_t* UiPanel::getWidth(ScriptEnvironment*, const wasm_val_t[],
-                               wasm_val_t results[]) {
+wasm_trap_t* UiPanel::getWidth(const wasm_val_t[], wasm_val_t results[]) {
   results[0].kind = WASM_F64;
   results[0].of.f64 = _size.x;
   return nullptr;
 }
 
-wasm_trap_t* UiPanel::getHeight(ScriptEnvironment*, const wasm_val_t[],
-                                wasm_val_t results[]) {
+wasm_trap_t* UiPanel::getHeight(const wasm_val_t[], wasm_val_t results[]) {
   results[0].kind = WASM_F64;
   results[0].of.f64 = _size.y;
   return nullptr;
 }
 
-wasm_trap_t* UiPanel::setSize(ScriptEnvironment*, const wasm_val_t args[],
-                              wasm_val_t results[]) {
+wasm_trap_t* UiPanel::setSize(const wasm_val_t args[], wasm_val_t results[]) {
   _size.x = args[1].of.f64;
   _size.y = args[2].of.f64;
   return nullptr;
 }
 
-wasm_trap_t* UiPanel::setColor(ScriptEnvironment*, const wasm_val_t args[],
-                               wasm_val_t results[]) {
+wasm_trap_t* UiPanel::setColor(const wasm_val_t args[], wasm_val_t results[]) {
   _color.r = args[1].of.f64;
   _color.g = args[2].of.f64;
   _color.b = args[3].of.f64;
@@ -77,8 +73,7 @@ wasm_trap_t* UiPanel::setColor(ScriptEnvironment*, const wasm_val_t args[],
   return nullptr;
 }
 
-wasm_trap_t* UiPanel::createGlyphStyle(ScriptEnvironment* scripts,
-                                       const wasm_val_t[],
+wasm_trap_t* UiPanel::createGlyphStyle(const wasm_val_t[],
                                        wasm_val_t results[]) {
   GlyphStyle* new_style = new GlyphStyle(glyphs, scripts, this);
   _styles.push_back(new_style);

--- a/core/ui/UiPanel.h
+++ b/core/ui/UiPanel.h
@@ -39,12 +39,11 @@ class UiPanel : public DynamicScriptObject<UiPanel> {
   //
   // Scripting methods
   //
-  wasm_trap_t* getWidth(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* getHeight(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* setSize(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* setColor(ScriptEnvironment*, const wasm_val_t[], wasm_val_t[]);
-  wasm_trap_t* createGlyphStyle(ScriptEnvironment*, const wasm_val_t[],
-                                wasm_val_t[]);
+  wasm_trap_t* getWidth(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* getHeight(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* setSize(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* setColor(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* createGlyphStyle(const wasm_val_t[], wasm_val_t[]);
 
  private:
   GlyphLoader* glyphs;

--- a/core/world/ScriptEntity.cc
+++ b/core/world/ScriptEntity.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2020-2021 the Mondradiko contributors.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "core/world/ScriptEntity.h"
+
+#include "core/components/TransformComponent.h"
+#include "core/scripting/ScriptEnvironment.h"
+#include "core/world/World.h"
+
+namespace mondradiko {
+namespace core {
+
+const wasm_functype_t* methodType_Entity() {
+  return wasm_functype_new_1_1(wasm_valtype_new_i32(), wasm_valtype_new_i32());
+}
+
+template <class ComponentType>
+static wasm_trap_t* Entity_hasComponent(World* world, const wasm_val_t args[],
+                                        wasm_val_t results[]) {
+  results[0].kind = WASM_I32;
+
+  if (world->registry.has<ComponentType>(args[0].of.i32)) {
+    results[0].of.i32 = 1;
+  } else {
+    results[0].of.i32 = 0;
+  }
+
+  return nullptr;
+}
+
+template <class ComponentType>
+static wasm_trap_t* Entity_addComponent(World* world, const wasm_val_t args[],
+                                        wasm_val_t results[]) {
+  results[0].kind = WASM_I32;
+  results[0].of.i32 = args[0].of.i32;
+
+  if (!world->registry.has<ComponentType>(args[0].of.i32)) {
+    world->registry.emplace<ComponentType>(args[0].of.i32);
+  }
+
+  return nullptr;
+}
+
+static wasm_trap_t* Entity_getComponent(World*, const wasm_val_t args[],
+                                        wasm_val_t results[]) {
+  results[0].kind = WASM_I32;
+  results[0].of.i32 = args[0].of.i32;
+  return nullptr;
+}
+
+using BoundEntityMethod = wasm_trap_t* (*)(World*, const wasm_val_t[],
+                                           wasm_val_t[]);
+
+using EntityMethodTypeCallback = const wasm_functype_t* (*)();
+
+static void finalizer(void*) {}
+
+template <BoundEntityMethod method>
+wasm_trap_t* entityMethodWrapper(const wasmtime_caller_t* caller, void* env,
+                                 const wasm_val_t args[],
+                                 wasm_val_t results[]) {
+  World* world = reinterpret_cast<World*>(env);
+
+  if (!world->registry.valid(args[0].of.i32)) {
+    return world->scripts->createTrap("Invalid entity ID");
+  }
+
+  return (*method)(world, args, results);
+}
+
+template <BoundEntityMethod method>
+void linkEntityMethod(ScriptEnvironment* scripts, World* world,
+                      const char* symbol,
+                      EntityMethodTypeCallback type_callback) {
+  wasm_store_t* store = scripts->getStore();
+
+  const wasm_functype_t* func_type = (*type_callback)();
+
+  wasmtime_func_callback_with_env_t callback = entityMethodWrapper<method>;
+
+  void* env = static_cast<void*>(world);
+
+  wasm_func_t* func =
+      wasmtime_func_new_with_env(store, func_type, callback, env, finalizer);
+
+  scripts->addBinding(symbol, func);
+}
+
+void ScriptEntity::linkScriptApi(ScriptEnvironment* scripts, World* world) {
+  linkEntityMethod<Entity_getComponent>(scripts, world, "Entity_getComponent",
+                                        methodType_Entity);
+  linkEntityMethod<Entity_hasComponent<TransformComponent>>(
+      scripts, world, "Entity_hasTransform", methodType_Entity);
+  linkEntityMethod<Entity_addComponent<TransformComponent>>(
+      scripts, world, "Entity_addTransform", methodType_Entity);
+}
+
+}  // namespace core
+}  // namespace mondradiko

--- a/core/world/ScriptEntity.cc
+++ b/core/world/ScriptEntity.cc
@@ -3,6 +3,7 @@
 
 #include "core/world/ScriptEntity.h"
 
+#include "core/components/PointLightComponent.h"
 #include "core/components/TransformComponent.h"
 #include "core/scripting/ScriptEnvironment.h"
 #include "core/world/World.h"
@@ -89,6 +90,10 @@ void linkEntityMethod(ScriptEnvironment* scripts, World* world,
 void ScriptEntity::linkScriptApi(ScriptEnvironment* scripts, World* world) {
   linkEntityMethod<Entity_getComponent>(scripts, world, "Entity_getComponent",
                                         methodType_Entity);
+  linkEntityMethod<Entity_hasComponent<PointLightComponent>>(
+      scripts, world, "Entity_hasPointLight", methodType_Entity);
+  linkEntityMethod<Entity_addComponent<PointLightComponent>>(
+      scripts, world, "Entity_addPointLight", methodType_Entity);
   linkEntityMethod<Entity_hasComponent<TransformComponent>>(
       scripts, world, "Entity_hasTransform", methodType_Entity);
   linkEntityMethod<Entity_addComponent<TransformComponent>>(

--- a/core/world/ScriptEntity.h
+++ b/core/world/ScriptEntity.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2020-2021 the Mondradiko contributors.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+namespace mondradiko {
+namespace core {
+
+// Forward declarations
+class ScriptEnvironment;
+class World;
+
+class ScriptEntity {
+ public:
+  static void linkScriptApi(ScriptEnvironment*, World*);
+};
+
+}  // namespace core
+}  // namespace mondradiko

--- a/core/world/World.cc
+++ b/core/world/World.cc
@@ -23,7 +23,11 @@ namespace mondradiko {
 namespace core {
 
 World::World(AssetPool* asset_pool, Filesystem* fs, ScriptEnvironment* scripts)
-    : asset_pool(asset_pool), fs(fs), scripts(scripts), physics(this) {
+    : StaticScriptObject(scripts, "World"),
+      asset_pool(asset_pool),
+      fs(fs),
+      scripts(scripts),
+      physics(this) {
   log_zone;
 
   asset_pool->initializeAssetType<PrefabAsset>(asset_pool);
@@ -278,6 +282,26 @@ void World::updateComponents(
       handle.refresh(asset_pool);
     }
   }
+}
+
+wasm_trap_t* World::spawnEntity(const wasm_val_t args[], wasm_val_t results[]) {
+  EntityId new_entity = registry.create();
+  results[0].kind = WASM_I32;
+  results[0].of.i32 = new_entity;
+  return nullptr;
+}
+
+wasm_trap_t* World::spawnEntityAt(const wasm_val_t args[],
+                                  wasm_val_t results[]) {
+  EntityId new_entity = registry.create();
+
+  registry.emplace<TransformComponent>(
+      new_entity, glm::vec3(args[0].of.f64, args[1].of.f64, args[2].of.f64),
+      glm::quat());
+
+  results[0].kind = WASM_I32;
+  results[0].of.i32 = new_entity;
+  return nullptr;
 }
 
 }  // namespace core

--- a/core/world/World.h
+++ b/core/world/World.h
@@ -6,6 +6,7 @@
 #include "core/assets/AssetPool.h"
 #include "core/physics/Physics.h"
 #include "core/scripting/ScriptEnvironment.h"
+#include "core/scripting/ScriptObject.h"
 #include "core/world/Entity.h"
 #include "lib/include/flatbuffers_headers.h"
 
@@ -25,7 +26,7 @@ namespace core {
 // Forward declarations
 class Filesystem;
 
-class World {
+class World : public StaticScriptObject<World> {
  public:
   World(AssetPool*, Filesystem*, ScriptEnvironment*);
   ~World();
@@ -57,6 +58,12 @@ class World {
   void updateComponents(
       const flatbuffers::Vector<EntityId>*,
       const flatbuffers::Vector<const ProtocolComponentType*>*);
+
+  //
+  // Scripting methods
+  //
+  wasm_trap_t* spawnEntity(const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* spawnEntityAt(const wasm_val_t[], wasm_val_t[]);
 
   // TODO(marceline-cramer) Blech, restore World privacy
   // Move event callbacks to private

--- a/core/world/WorldEventSorter.cc
+++ b/core/world/WorldEventSorter.cc
@@ -31,9 +31,9 @@ flatbuffers::Offset<protocol::WorldEvent> updateComponents(
     flatbuffers::FlatBufferBuilder* builder, EntityRegistry* registry) {
   using ProtocolComponentType = typename ComponentType::SerializedType;
 
-  static_assert(
-      std::is_base_of<Component<ProtocolComponentType>, ComponentType>(),
-      "ComponentType must inherit from Component");
+  static_assert(std::is_base_of<SynchronizedComponent<ProtocolComponentType>,
+                                ComponentType>(),
+                "ComponentType must inherit from SynchronizedComponent");
 
   auto component_view = registry->view<ComponentType>();
 


### PR DESCRIPTION
- [x] Adds `DynamicScriptObject`, `StaticScriptObject`, and `ScriptableComponent` for scriptable objects
- [x] Adds a `ScriptEntity` class to operate on entities from scripts
- [x] Binds `PointLightComponent` and `World`
- [x] Adds `ScriptEnvironment` helper methods
- [x] Fixes `ScriptInstance` initialization crashes
- [x] Removes solved to-dos
- [x] Updates in-repo documentation
- [x] Adds to-dos for future PRs
