### PR TITLE
Upgrade converter

### DIFF
--- a/bundler/Bundler.cc
+++ b/bundler/Bundler.cc
@@ -159,7 +159,7 @@ void Bundler::bundle() {
       }
 
       flatbuffers::FlatBufferBuilder fbb;
-      auto asset_offset = iter->second->convert(&fbb, asset_path);
+      auto asset_offset = iter->second->convert(&fbb, asset);
 
       assets::AssetId asset_id;
       bundle_builder->addAsset(&asset_id, &fbb, asset_offset);

--- a/bundler/Bundler.h
+++ b/bundler/Bundler.h
@@ -27,6 +27,7 @@ class Bundler : public converter::BundlerInterface {
                            converter::ConverterInterface::AssetOffset) final;
   void addConverter(std::string, const converter::ConverterInterface*) final;
   assets::AssetId getAssetByAlias(const std::string&) final;
+  std::filesystem::path getAssetPath(const toml::table&) final;
   void bundle() final;
 
  private:

--- a/converter/BundlerInterface.h
+++ b/converter/BundlerInterface.h
@@ -24,6 +24,7 @@ class BundlerInterface {
                                    ConverterInterface::AssetOffset) = 0;
   virtual void addConverter(std::string, const ConverterInterface*) = 0;
   virtual assets::AssetId getAssetByAlias(const std::string&) = 0;
+  virtual std::filesystem::path getAssetPath(const toml::table&) = 0;
   virtual void bundle() = 0;
 };
 

--- a/converter/ConverterInterface.h
+++ b/converter/ConverterInterface.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include "converter/AssetBundleBuilder.h"
+#include "lib/include/toml_headers.h"
 #include "types/assets/AssetTypes.h"
 #include "types/assets/SerializedAsset_generated.h"
 
@@ -20,7 +19,7 @@ class ConverterInterface {
   using AssetOffset = flatbuffers::Offset<assets::SerializedAsset>;
   using AssetBuilder = flatbuffers::FlatBufferBuilder;
 
-  virtual AssetOffset convert(AssetBuilder*, std::filesystem::path) const = 0;
+  virtual AssetOffset convert(AssetBuilder*, const toml::table&) const = 0;
 };
 
 }  // namespace converter

--- a/converter/prefab/BinaryGltfConverter.cc
+++ b/converter/prefab/BinaryGltfConverter.cc
@@ -5,13 +5,16 @@
 
 #include <string>
 
+#include "converter/BundlerInterface.h"
 #include "log/log.h"
 
 namespace mondradiko {
 namespace converter {
 
 ConverterInterface::AssetOffset BinaryGltfConverter::convert(
-    AssetBuilder* fbb, std::filesystem::path model_path) const {
+    AssetBuilder* fbb, const toml::table& asset) const {
+  auto model_path = _bundler->getAssetPath(asset);
+
   tinygltf::Model gltf_model;
   tinygltf::TinyGLTF gltf_context;
   std::string error;

--- a/converter/prefab/BinaryGltfConverter.h
+++ b/converter/prefab/BinaryGltfConverter.h
@@ -14,7 +14,7 @@ class BinaryGltfConverter : public GltfConverter {
       : GltfConverter(bundler) {}
 
   // ConverterInterface implementation
-  AssetOffset convert(AssetBuilder*, std::filesystem::path) const final;
+  AssetOffset convert(AssetBuilder*, const toml::table&) const final;
 };
 
 }  // namespace converter

--- a/converter/prefab/TextGltfConverter.cc
+++ b/converter/prefab/TextGltfConverter.cc
@@ -5,13 +5,16 @@
 
 #include <string>
 
+#include "converter/BundlerInterface.h"
 #include "log/log.h"
 
 namespace mondradiko {
 namespace converter {
 
 ConverterInterface::AssetOffset TextGltfConverter::convert(
-    AssetBuilder* fbb, std::filesystem::path model_path) const {
+    AssetBuilder* fbb, const toml::table& asset) const {
+  auto model_path = _bundler->getAssetPath(asset);
+
   tinygltf::Model gltf_model;
   tinygltf::TinyGLTF gltf_context;
   std::string error;

--- a/converter/prefab/TextGltfConverter.h
+++ b/converter/prefab/TextGltfConverter.h
@@ -14,7 +14,7 @@ class TextGltfConverter : public GltfConverter {
       : GltfConverter(bundler) {}
 
   // ConverterInterface implementation
-  AssetOffset convert(AssetBuilder*, std::filesystem::path) const final;
+  AssetOffset convert(AssetBuilder*, const toml::table&) const final;
 };
 
 }  // namespace converter

--- a/converter/script/WasmConverter.cc
+++ b/converter/script/WasmConverter.cc
@@ -6,13 +6,16 @@
 #include <fstream>
 #include <vector>
 
+#include "converter/BundlerInterface.h"
 #include "log/log.h"
 
 namespace mondradiko {
 namespace converter {
 
 WasmConverter::AssetOffset WasmConverter::convert(
-    AssetBuilder* fbb, std::filesystem::path wasm_path) const {
+    AssetBuilder* fbb, const toml::table& asset) const {
+  auto wasm_path = _bundler->getAssetPath(asset);
+
   std::ifstream script_file(wasm_path, std::ifstream::binary);
 
   if (!script_file) {
@@ -35,10 +38,10 @@ WasmConverter::AssetOffset WasmConverter::convert(
   script_asset.add_data(data_offset);
   auto script_offset = script_asset.Finish();
 
-  assets::SerializedAssetBuilder asset(*fbb);
-  asset.add_type(assets::AssetType::ScriptAsset);
-  asset.add_script(script_offset);
-  auto asset_offset = asset.Finish();
+  assets::SerializedAssetBuilder serialized_asset(*fbb);
+  serialized_asset.add_type(assets::AssetType::ScriptAsset);
+  serialized_asset.add_script(script_offset);
+  auto asset_offset = serialized_asset.Finish();
 
   return asset_offset;
 }

--- a/converter/script/WasmConverter.h
+++ b/converter/script/WasmConverter.h
@@ -16,7 +16,7 @@ class WasmConverter : public ConverterInterface {
   explicit WasmConverter(BundlerInterface* bundler) : _bundler(bundler) {}
 
   // ConverterInterface implementation
-  AssetOffset convert(AssetBuilder*, std::filesystem::path) const final;
+  AssetOffset convert(AssetBuilder*, const toml::table&) const final;
 
  private:
   BundlerInterface* _bundler;


### PR DESCRIPTION
Passes the `toml::table` values from the manifest directly to `ConverterInterface`, while providing a virtual helper method, `BundlerInterface::getAssetPath()`, to retrieve the asset path from the usual `file` member of the manifest.