### PR TITLE
Fix FlatBuffers quaternion conversion order

### DIFF
--- a/types/assets/AssetTypes.cc
+++ b/types/assets/AssetTypes.cc
@@ -61,10 +61,10 @@ void GlmToVec4(Vec4* dst, const glm::vec4& src) {
 
 void GlmToQuat(Quaternion* dst, const glm::quat& src) {
   auto v = dst->mutable_v();
-  v->Mutate(0, src.w);
-  v->Mutate(1, src.x);
-  v->Mutate(2, src.y);
-  v->Mutate(3, src.z);
+  v->Mutate(0, src.x);
+  v->Mutate(1, src.y);
+  v->Mutate(2, src.z);
+  v->Mutate(3, src.w);
 }
 
 }  // namespace assets

--- a/types/protocol/ProtocolTypes.cc
+++ b/types/protocol/ProtocolTypes.cc
@@ -21,10 +21,10 @@ void GlmToVec3(Vec3* dst, const glm::vec3& src) {
 
 void GlmToQuat(Quaternion* dst, const glm::quat& src) {
   auto v = dst->mutable_v();
-  v->Mutate(0, src.w);
-  v->Mutate(1, src.x);
-  v->Mutate(2, src.y);
-  v->Mutate(3, src.z);
+  v->Mutate(0, src.x);
+  v->Mutate(1, src.y);
+  v->Mutate(2, src.z);
+  v->Mutate(3, src.w);
 }
 
 }  // namespace protocol


### PR DESCRIPTION
Due to glm inconsistencies, assets and protocol data written to FlatBuffers quaternion structures were being unpacked the wrong way. The conversion helpers wrote the quaternions as `(w, x, y, z)`, which is the order in the `glm::quat` constructor, but `glm::make_quat()` was unpacking them as `(x, y, z, w)`, which is `glm::quat`'s internal order.