### PR TITLE
Fix/gpuvector

### DIFF
--- a/core/gpu/GpuVector.h
+++ b/core/gpu/GpuVector.h
@@ -49,7 +49,11 @@ void GpuVector::writeElement(uint32_t index, const ElementType& element) {
   }
 
   size_t needed_size = (index + 1) * element_granularity;
-  reserve(needed_size);
+
+  if (needed_size > buffer_size) {
+    size_t larger_size = buffer_size << 1;
+    reserve(needed_size > larger_size ? needed_size : larger_size);
+  }
 
   memcpy(static_cast<char*>(allocation_info.pMappedData) +
              index * element_granularity,

--- a/core/renderer/Renderer.cc
+++ b/core/renderer/Renderer.cc
@@ -403,7 +403,6 @@ void Renderer::renderFrame() {
     log_zone_named("Begin frame");
 
     viewport_descriptor = frame.descriptor_pool->allocate(viewport_layout);
-    viewport_descriptor->updateDynamicBuffer(0, frame.viewports);
 
     for (auto& render_pass : render_passes) {
       render_pass->beginFrame(current_frame, frame.descriptor_pool);
@@ -458,6 +457,18 @@ void Renderer::renderFrame() {
   }
 
   {
+    log_zone_named("Write viewport uniforms");
+
+    for (uint32_t i = 0; i < viewports.size(); i++) {
+      ViewportUniform uniform;
+      viewports[i]->writeUniform(&uniform);
+      frame.viewports->writeElement(i, uniform);
+    }
+
+    viewport_descriptor->updateDynamicBuffer(0, frame.viewports);
+  }
+
+  {
     log_zone_named("Render viewports");
 
     for (uint32_t viewport_index = 0; viewport_index < viewports.size();
@@ -485,16 +496,6 @@ void Renderer::renderFrame() {
     }
 
     vkEndCommandBuffer(frame.command_buffer);
-  }
-
-  {
-    log_zone_named("Write viewport uniforms");
-
-    for (uint32_t i = 0; i < viewports.size(); i++) {
-      ViewportUniform uniform;
-      viewports[i]->writeUniform(&uniform);
-      frame.viewports->writeElement(i, uniform);
-    }
   }
 
   {

--- a/core/ui/UserInterface.cc
+++ b/core/ui/UserInterface.cc
@@ -264,14 +264,6 @@ void UserInterface::beginFrame(uint32_t frame_index,
     }
   }
 
-  frame.panels_descriptor = descriptor_pool->allocate(panel_layout);
-  frame.panels_descriptor->updateStorageBuffer(0, frame.panels);
-
-  frame.glyph_descriptor = descriptor_pool->allocate(glyph_set_layout);
-  frame.glyph_descriptor->updateImage(0, glyphs->getAtlas());
-  frame.glyph_descriptor->updateStorageBuffer(1, frame.styles);
-  frame.glyph_descriptor->updateStorageBuffer(2, glyphs->getGlyphs());
-
   frame.glyph_count = 0;
 
   for (uint32_t i = 0; i < test_string.size(); i++) {
@@ -282,6 +274,14 @@ void UserInterface::beginFrame(uint32_t frame_index,
   for (uint32_t i = 0; i < styles.size(); i++) {
     frame.styles->writeElement(i, styles[i]->getUniform());
   }
+
+  frame.panels_descriptor = descriptor_pool->allocate(panel_layout);
+  frame.panels_descriptor->updateStorageBuffer(0, frame.panels);
+
+  frame.glyph_descriptor = descriptor_pool->allocate(glyph_set_layout);
+  frame.glyph_descriptor->updateImage(0, glyphs->getAtlas());
+  frame.glyph_descriptor->updateStorageBuffer(1, frame.styles);
+  frame.glyph_descriptor->updateStorageBuffer(2, glyphs->getGlyphs());
 }
 
 void UserInterface::renderViewport(


### PR DESCRIPTION
- [x] `GpuVector` doubles maximum size when realloc-ing
- [x] `UserInterface` and `Renderer` treat their GPU vector data correctly (updating descriptors after writes to vectors are complete)
- [x] Fixes those pesky Vulkan validation messages about command buffers using destroyed buffers that we've been dealing with since forever
- [x] Fixes crashes related to that validation message
