### PR TITLE
Fix OpenXR

### DIFF
--- a/client/client_main.cc
+++ b/client/client_main.cc
@@ -37,6 +37,8 @@ struct ClientArgs {
   std::string server_ip = "127.0.0.1";
   int server_port = 10555;
 
+  std::string display = "sdl";
+
   std::vector<std::string> bundle_paths = {"./"};
 
   std::string config_path = "./config.toml";
@@ -59,6 +61,8 @@ int ClientArgs::parse(int argc, const char* const argv[]) {
   CLI::Option* port_op =
       app.add_option("-p,--port", server_port, "Domain server port", true);
   port_op->needs(server_op);
+
+  app.add_option("-d,--display", display, "Display to use {sdl, openxr}", true);
 
   app.add_option("-b,--bundle", bundle_paths, "Paths to asset bundles", true);
   app.add_option("-c,--config", config_path, "Path to config file", true);
@@ -88,7 +92,15 @@ void run(const ClientArgs& args) {
   }
 
   std::unique_ptr<DisplayInterface> display;
-  display = std::make_unique<SdlDisplay>(display_cvars);
+
+  if (args.display == "sdl") {
+    display = std::make_unique<SdlDisplay>(display_cvars);
+  } else if (args.display == "openxr") {
+    display = std::make_unique<OpenXrDisplay>();
+  } else {
+    log_ftl_fmt("Unrecognized display \"%s\" (must be {sdl, openxr})",
+                args.display.c_str());
+  }
 
   GpuInstance gpu(display.get());
   if (!display->createSession(&gpu)) {

--- a/config/config.toml
+++ b/config/config.toml
@@ -15,6 +15,12 @@ sdf_scale = 2.0
 sdf_border = 1.0
 sdf_range = 4.0
 
+[renderer]
+
+# Calls vkQueueWaitIdle after every submit.
+# Stops Monado from flickering, but stalls the CPU.
+queue_stall = false
+
 [renderer.debug]
 enabled = true
 draw_lights = true

--- a/core/displays/OpenXrDisplay.cc
+++ b/core/displays/OpenXrDisplay.cc
@@ -127,8 +127,6 @@ OpenXrDisplay::OpenXrDisplay() {
 OpenXrDisplay::~OpenXrDisplay() {
   log_zone;
 
-  destroySession();
-
   if (enable_validation_layers && debug_messenger != VK_NULL_HANDLE)
     ext_xrDestroyDebugUtilsMessengerEXT(debug_messenger);
 

--- a/core/renderer/Renderer.cc
+++ b/core/renderer/Renderer.cc
@@ -3,6 +3,7 @@
 
 #include "core/renderer/Renderer.h"
 
+#include "core/cvars/BoolCVar.h"
 #include "core/cvars/CVarScope.h"
 #include "core/displays/DisplayInterface.h"
 #include "core/displays/Viewport.h"
@@ -21,8 +22,9 @@ namespace core {
 
 void Renderer::initCVars(CVarScope* cvars) {
   CVarScope* renderer = cvars->addChild("renderer");
-
   OverlayPass::initCVars(renderer);
+
+  renderer->addValue<BoolCVar>("queue_stall");
 }
 
 Renderer::Renderer(const CVarScope* cvars, DisplayInterface* display,
@@ -528,6 +530,11 @@ void Renderer::renderFrame() {
         VK_SUCCESS) {
       log_ftl("Failed to submit primary frame command buffer.");
     }
+  }
+
+  if (cvars->get<BoolCVar>("queue_stall")) {
+    log_zone_named("Stall queue after submit");
+    vkQueueWaitIdle(gpu->graphics_queue);
   }
 
   {

--- a/core/renderer/Renderer.cc
+++ b/core/renderer/Renderer.cc
@@ -473,8 +473,7 @@ void Renderer::renderFrame() {
 
     for (uint32_t viewport_index = 0; viewport_index < viewports.size();
          viewport_index++) {
-      viewport_descriptor->updateDynamicOffset(
-          0, viewport_index * sizeof(ViewportUniform));
+      viewport_descriptor->updateDynamicOffset(0, viewport_index);
       viewports[viewport_index]->beginRenderPass(frame.command_buffer,
                                                  render_pass);
 


### PR DESCRIPTION
- [x] Fixes Vulkan validation issues from multiple viewport dynamic uniform buffer offsets
- [x] Fixes segfault in `OpenXrDisplay::destroySession()` caused by a second call
- [x] Adds a `--display` client command-line option to select which display frontend to use (SDL or OpenXR)
- [x] Adds the `renderer.queue_stall` cvar to get Monado to stop flickering after submission