### PR TITLE
Fix color space

### DIFF
--- a/core/displays/OpenXrDisplay.cc
+++ b/core/displays/OpenXrDisplay.cc
@@ -181,7 +181,7 @@ bool OpenXrDisplay::createSession(GpuInstance* _gpu) {
     format_options[i] = static_cast<VkFormat>(format_codes[i]);
   }
 
-  types::vector<VkFormat> format_candidates = {VK_FORMAT_R8G8B8A8_SRGB,
+  types::vector<VkFormat> format_candidates = {VK_FORMAT_R8G8B8_UNORM,
                                                VK_FORMAT_R8G8B8A8_UNORM};
 
   if (!gpu->findFormatFromOptions(&format_options, &format_candidates,

--- a/core/displays/SdlDisplay.cc
+++ b/core/displays/SdlDisplay.cc
@@ -130,7 +130,7 @@ bool SdlDisplay::getVulkanDevice(VkInstance instance,
 
   swapchain_format = VK_FORMAT_MAX_ENUM;
   for (const auto& surface_format : surface_formats) {
-    if (surface_format.format == VK_FORMAT_B8G8R8A8_SRGB &&
+    if (surface_format.format == VK_FORMAT_B8G8R8A8_UNORM &&
         surface_format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
       swapchain_format = surface_format.format;
       swapchain_color_space = surface_format.colorSpace;

--- a/core/displays/Viewport.cc
+++ b/core/displays/Viewport.cc
@@ -126,7 +126,7 @@ void Viewport::_createImages() {
     VkImageUsageFlags depth_usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
     VkFormat hdr_format = display->getHdrFormat();
-    VkFormat overlay_format = VK_FORMAT_R8G8B8A8_SRGB;
+    VkFormat overlay_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormat depth_format = display->getDepthFormat();
 
     _hdr_image = std::make_unique<GpuImage>(

--- a/core/gpu/GraphicsState.cc
+++ b/core/gpu/GraphicsState.cc
@@ -179,7 +179,7 @@ VkPipelineColorBlendAttachmentState GraphicsState::createVkColorBlendState()
   VkPipelineColorBlendAttachmentState info{};
 
   info.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                        VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+                        VK_COLOR_COMPONENT_B_BIT;
 
   switch (color_blend_state.blend_mode) {
     case GraphicsState::BlendMode::Opaque: {
@@ -189,6 +189,7 @@ VkPipelineColorBlendAttachmentState GraphicsState::createVkColorBlendState()
 
     case GraphicsState::BlendMode::AlphaBlend: {
       info.blendEnable = VK_TRUE;
+      info.colorWriteMask |= VK_COLOR_COMPONENT_A_BIT;
 
       info.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
       info.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
@@ -202,6 +203,7 @@ VkPipelineColorBlendAttachmentState GraphicsState::createVkColorBlendState()
 
     case GraphicsState::BlendMode::AlphaPremultiplied: {
       info.blendEnable = VK_TRUE;
+      info.colorWriteMask |= VK_COLOR_COMPONENT_A_BIT;
 
       info.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
       info.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;

--- a/core/renderer/Renderer.cc
+++ b/core/renderer/Renderer.cc
@@ -76,7 +76,7 @@ Renderer::Renderer(const CVarScope* cvars, Display* display, GpuInstance* gpu)
 
     {
       VkAttachmentDescription overlay_desc{};
-      overlay_desc.format = VK_FORMAT_R8G8B8A8_SRGB;
+      overlay_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
       overlay_desc.samples = VK_SAMPLE_COUNT_1_BIT;
       overlay_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
       overlay_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -319,7 +319,7 @@ Renderer::Renderer(const CVarScope* cvars, Display* display, GpuInstance* gpu)
 
     {
       VkAttachmentDescription overlay_desc{};
-      overlay_desc.format = VK_FORMAT_R8G8B8A8_SRGB;
+      overlay_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
       overlay_desc.samples = VK_SAMPLE_COUNT_1_BIT;
       overlay_desc.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
       overlay_desc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;

--- a/core/shaders/composite.frag
+++ b/core/shaders/composite.frag
@@ -7,7 +7,29 @@
 layout(input_attachment_index = 0, set = 1, binding = 0) uniform subpassInput inputHdr;
 layout(input_attachment_index = 0, set = 1, binding = 1) uniform subpassInput inputOverlay;
 
-layout(location = 0) out vec4 outColor;
+layout(location = 0) out vec3 outColor;
+
+// Converts a color from linear light gamma to sRGB gamma
+// From:
+// https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
+// Enhanced for performance
+// Removed the alpha calculation
+vec3 ConvertLinearToSRgb(vec3 rgb)
+{
+  bvec3 cutoff = lessThan(rgb, vec3(0.0031308));
+  vec3 lower = rgb * vec3(12.92);
+
+  // This branch is OK because lighter fragments will be closer to each other
+  // Meaning that most quads/subgroups will take the same branch
+  // This is further enhanced by post-processing like FXAA and bloom
+  // This has been tested and it shows a definite speed improvement
+  if (all(cutoff)) {
+    return lower;
+  } else {
+    vec3 higher = vec3(1.055)*pow(rgb, vec3(1.0/2.4)) - vec3(0.055);
+    return mix(higher, lower, cutoff);
+  }
+}
 
 void main() {
   vec3 luminance = subpassLoad(inputHdr).rgb;
@@ -15,7 +37,7 @@ void main() {
 
   vec4 overlay = subpassLoad(inputOverlay);
 
-  outColor = vec4(tone_mapped, 1.0);
+  outColor = ConvertLinearToSRgb(tone_mapped);
   outColor *= 1.0 - overlay.a;
-  outColor += overlay;
+  outColor += overlay.rgb;
 }


### PR DESCRIPTION
Fixes some incorrect color space management that was causing some UI color inconsistencies.

- [x] Changes overlay image format from sRGB to UNORM
- [x] Set the swapchain image format to UNORM
- [x] Add assertions for `OpenXrDisplay` OpenXR session begin calls (hopefully giving a lead on why SteamVR is crashing)
- [x] Disables `GraphicsState::BlendMode::Opaque` alpha write mask
- [x] Does gamma correction in compositing fragment shader