### PR TITLE
Add world scripts

### DIFF
--- a/client/client_main.cc
+++ b/client/client_main.cc
@@ -108,7 +108,7 @@ void run(const ClientArgs& args) {
   AssetPool asset_pool(&fs);
 
   // TODO(marceline-cramer) Serverless world scripts
-  World world(&asset_pool, &fs, nullptr);
+  World world(&asset_pool, &fs);
 
   Renderer renderer(&cvars, display.get(), &gpu);
   GlyphLoader glyphs(&cvars, &renderer);

--- a/codegen/types/Vector3.ts
+++ b/codegen/types/Vector3.ts
@@ -8,6 +8,10 @@ export default class Vector3 {
 
   constructor(public x: f64, public y: f64, public z: f64) {}
 
+  static random(): Vector3 {
+    return new Vector3(Math.random(), Math.random(), Math.random());
+  }
+
   clone(): Vector3 { return new Vector3(this.x, this.y, this.z); }
 
   static readonly Zero: Vector3 = new Vector3(0.0, 0.0, 0.0);
@@ -38,44 +42,50 @@ export default class Vector3 {
    * Vector-to-vector arithmetic
    */
 
-  add(other: Vector3): void {
+  add(other: Vector3): Vector3 {
     this.x += other.x;
     this.y += other.y;
     this.z += other.z;
+    return this;
   }
 
-  sub(other: Vector3): void {
+  sub(other: Vector3): Vector3 {
     this.x -= other.x;
     this.y -= other.y;
     this.z -= other.z;
+    return this;
   }
 
-  mul(other: Vector3): void {
+  mul(other: Vector3): Vector3 {
     this.x *= other.x;
     this.y *= other.y;
     this.z *= other.z;
+    return this;
   }
 
-  div(other: Vector3): void {
+  div(other: Vector3): Vector3 {
     this.x /= other.x;
     this.y /= other.y;
     this.z /= other.z;
+    return this;
   }
 
   /**
    * Vector-to-scalar arithmetic
    */
 
-  scale(s: f64): void {
+  scale(s: f64): Vector3 {
     this.x *= s;
     this.y *= s;
     this.z *= s;
+    return this;
   }
 
-  set(s: f64): void {
+  set(s: f64): Vector3 {
     this.x = s;
     this.y = s;
     this.z = s;
+    return this;
   }
 
   /**

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MONDRADIKO_CORE_SRC
   scripting/environment/ComponentScriptEnvironment.cc
   scripting/environment/ScriptEnvironment.cc
   scripting/environment/UiScriptEnvironment.cc
+  scripting/environment/WorldScriptEnvironment.cc
   scripting/instance/ComponentScript.cc
   scripting/instance/ScriptInstance.cc
   scripting/instance/UiScript.cc

--- a/core/components/internal/ScriptComponent.h
+++ b/core/components/internal/ScriptComponent.h
@@ -14,6 +14,8 @@ class ComponentScript;
 
 class ScriptComponent : public InternalComponent {
  public:
+  ComponentScript* getInstance() { return _script_instance; }
+
  private:
   // Systems allowed to access private members directly
   friend class ComponentScriptEnvironment;

--- a/core/scripting/environment/ComponentScriptEnvironment.cc
+++ b/core/scripting/environment/ComponentScriptEnvironment.cc
@@ -16,22 +16,26 @@
 namespace mondradiko {
 namespace core {
 
-ComponentScriptEnvironment::ComponentScriptEnvironment(AssetPool* asset_pool,
-                                                       World* world)
-    : asset_pool(asset_pool), world(world) {
+ComponentScriptEnvironment::ComponentScriptEnvironment(World* world)
+    : asset_pool(world->asset_pool), world(world) {
   log_zone;
 
   asset_pool->initializeAssetType<ScriptAsset>(this);
 
-  PointLightComponent::linkScriptApi(this, world);
-  TransformComponent::linkScriptApi(this, world);
-  ScriptEntity::linkScriptApi(world);
-
   world->registry.on_destroy<ScriptComponent>()
       .connect<&onScriptComponentDestroy>();
+
+  linkEnvironment(this, world);
 }
 
 ComponentScriptEnvironment::~ComponentScriptEnvironment() { log_zone; }
+
+void ComponentScriptEnvironment::linkEnvironment(ScriptEnvironment* scripts,
+                                                 World* world) {
+  PointLightComponent::linkScriptApi(scripts, world);
+  TransformComponent::linkScriptApi(scripts, world);
+  ScriptEntity::linkScriptApi(scripts, world);
+}
 
 void ComponentScriptEnvironment::update(double dt) {
   log_zone;

--- a/core/scripting/environment/ComponentScriptEnvironment.h
+++ b/core/scripting/environment/ComponentScriptEnvironment.h
@@ -18,8 +18,10 @@ class World;
 
 class ComponentScriptEnvironment : public ScriptEnvironment {
  public:
-  ComponentScriptEnvironment(AssetPool*, World*);
+  ComponentScriptEnvironment(World*);
   ~ComponentScriptEnvironment();
+
+  static void linkEnvironment(ScriptEnvironment*, World*);
 
   /**
    * @brief Updates all ScriptComponents in the world.

--- a/core/scripting/environment/WorldScriptEnvironment.cc
+++ b/core/scripting/environment/WorldScriptEnvironment.cc
@@ -1,0 +1,86 @@
+// Copyright (c) 2020-2021 the Mondradiko contributors.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "core/scripting/environment/WorldScriptEnvironment.h"
+
+#include "core/scripting/environment/ComponentScriptEnvironment.h"
+#include "core/scripting/instance/WorldScript.h"
+#include "core/world/ScriptEntity.h"
+#include "core/world/World.h"
+#include "log/log.h"
+
+namespace mondradiko {
+namespace core {
+
+WorldScriptEnvironment::WorldScriptEnvironment(World* world,
+                                               const types::string& script_path)
+    : world(world) {
+  log_zone;
+
+  ComponentScriptEnvironment::linkEnvironment(this, world);
+
+  if (!world->linkToEnvironment(this)) {
+    log_wrn("Failed to link to World");
+  }
+
+  wasi_config_t* wasi_config = wasi_config_new();
+  wasi_config_inherit_env(wasi_config);
+  wasi_config_inherit_stdin(wasi_config);
+  wasi_config_inherit_stderr(wasi_config);
+  wasi_config_inherit_stdout(wasi_config);
+
+  wasm_trap_t* trap = nullptr;
+  wasi_instance_t* wasi_instance = wasi_instance_new(
+      getStore(), "wasi_snapshot_preview1", wasi_config, &trap);
+
+  if (handleError(nullptr, trap)) {
+    log_ftl("Failed to create WASI instance");
+  }
+
+  wasmtime_linker_t* linker = wasmtime_linker_new(getStore());
+  wasmtime_error_t* error = nullptr;
+
+  error = wasmtime_linker_define_wasi(linker, wasi_instance);
+  if (handleError(error, nullptr)) {
+    log_ftl("Failed to link WASI");
+    wasmtime_linker_delete(linker);
+    wasi_instance_delete(wasi_instance);
+  }
+
+  types::vector<char> script_data;
+  if (!world->fs->loadBinaryFile(script_path, &script_data)) {
+    log_ftl("Failed to load world script");
+  }
+
+  wasm_module_t* module = loadBinaryModule(script_data);
+  if (module == nullptr) {
+    log_ftl("Failed to load script module");
+    wasmtime_linker_delete(linker);
+    wasi_instance_delete(wasi_instance);
+  }
+
+  _instance = new WorldScript(this, world);
+  _instance->initializeScriptFromLinker(module, linker);
+  _instance->runCallback("_start", nullptr, 0, nullptr, 0);
+}
+
+WorldScriptEnvironment::~WorldScriptEnvironment() {
+  log_zone;
+
+  if (_instance != nullptr) delete _instance;
+
+  world->linkToEnvironment(nullptr);
+}
+
+void WorldScriptEnvironment::update(double dt) {
+  log_zone;
+
+  wasm_val_t dt_arg;
+  dt_arg.kind = WASM_F64;
+  dt_arg.of.f64 = dt;
+
+  _instance->runCallback("on_update", &dt_arg, 1, nullptr, 0);
+}
+
+}  // namespace core
+}  // namespace mondradiko

--- a/core/scripting/environment/WorldScriptEnvironment.h
+++ b/core/scripting/environment/WorldScriptEnvironment.h
@@ -4,11 +4,27 @@
 #pragma once
 
 #include "core/scripting/environment/ScriptEnvironment.h"
+#include "types/containers/string.h"
 
 namespace mondradiko {
 namespace core {
 
-class WorldScriptEnvironment : public ScriptEnvironment {};
+// Forward declarations
+class World;
+class WorldScript;
+
+class WorldScriptEnvironment : public ScriptEnvironment {
+ public:
+  WorldScriptEnvironment(World*, const types::string&);
+  ~WorldScriptEnvironment();
+
+  void update(double);
+
+ private:
+  World* const world;
+
+  WorldScript* _instance = nullptr;
+};
 
 }  // namespace core
 }  // namespace mondradiko

--- a/core/scripting/instance/ComponentScript.cc
+++ b/core/scripting/instance/ComponentScript.cc
@@ -14,11 +14,12 @@ namespace core {
 ComponentScript::ComponentScript(ScriptEnvironment* scripts, World* world,
                                  const AssetHandle<ScriptAsset>& asset,
                                  EntityId self_id, const types::string& impl)
-    : ScriptInstance(scripts, asset->getModule()),
-      world(world),
+    : WorldScript(scripts, world),
       _asset(asset),
       _impl(impl),
       _self_id(self_id) {
+  initializeScript(asset->getModule());
+
   wasm_val_t self_arg;
   self_arg.kind = WASM_I32;
   self_arg.of.i32 = _self_id;

--- a/core/scripting/instance/ComponentScript.cc
+++ b/core/scripting/instance/ComponentScript.cc
@@ -5,13 +5,14 @@
 
 #include <array>
 
-#include "core/scripting/environment/ScriptEnvironment.h"
+#include "core/scripting/environment/ComponentScriptEnvironment.h"
 #include "log/log.h"
 
 namespace mondradiko {
 namespace core {
 
-ComponentScript::ComponentScript(ScriptEnvironment* scripts, World* world,
+ComponentScript::ComponentScript(ComponentScriptEnvironment* scripts,
+                                 World* world,
                                  const AssetHandle<ScriptAsset>& asset,
                                  EntityId self_id, const types::string& impl)
     : WorldScript(scripts, world),

--- a/core/scripting/instance/ComponentScript.h
+++ b/core/scripting/instance/ComponentScript.h
@@ -13,12 +13,14 @@ namespace mondradiko {
 namespace core {
 
 // Forward declarations
+class ComponentScriptEnvironment;
 class World;
 
 class ComponentScript : public WorldScript {
  public:
-  ComponentScript(ScriptEnvironment*, World*, const AssetHandle<ScriptAsset>&,
-                  EntityId, const types::string&);
+  ComponentScript(ComponentScriptEnvironment*, World*,
+                  const AssetHandle<ScriptAsset>&, EntityId,
+                  const types::string&);
   ~ComponentScript();
 
   const AssetHandle<ScriptAsset>& getAsset() { return _asset; }

--- a/core/scripting/instance/ComponentScript.h
+++ b/core/scripting/instance/ComponentScript.h
@@ -5,7 +5,7 @@
 
 #include "core/assets/AssetHandle.h"
 #include "core/assets/ScriptAsset.h"
-#include "core/scripting/instance/ScriptInstance.h"
+#include "core/scripting/instance/WorldScript.h"
 #include "core/world/Entity.h"
 #include "types/containers/string.h"
 
@@ -15,7 +15,7 @@ namespace core {
 // Forward declarations
 class World;
 
-class ComponentScript : public ScriptInstance {
+class ComponentScript : public WorldScript {
  public:
   ComponentScript(ScriptEnvironment*, World*, const AssetHandle<ScriptAsset>&,
                   EntityId, const types::string&);
@@ -27,9 +27,6 @@ class ComponentScript : public ScriptInstance {
 
   // TODO(marceline-cramer) Actually update instance data
   void updateData(const uint8_t*, size_t) {}
-
-  // Publically-accessible World instance
-  World* const world;
 
  private:
   AssetHandle<ScriptAsset> _asset;

--- a/core/scripting/instance/ScriptInstance.h
+++ b/core/scripting/instance/ScriptInstance.h
@@ -54,6 +54,7 @@ class ScriptInstance {
   ~ScriptInstance();
 
   void initializeScript(wasm_module_t*);
+  void initializeScriptFromLinker(wasm_module_t*, wasmtime_linker_t*);
   void initializeScriptRaw(wasm_module_t*, wasm_instance_t*);
   void terminateScript();
 

--- a/core/scripting/instance/ScriptInstance.h
+++ b/core/scripting/instance/ScriptInstance.h
@@ -45,8 +45,17 @@ struct ASObjectHeader {
 
 class ScriptInstance {
  public:
+  //////////////////////////////////////////////////////////////////////////////
+  // Setup
+  //////////////////////////////////////////////////////////////////////////////
+
+  ScriptInstance(ScriptEnvironment*);
   ScriptInstance(ScriptEnvironment*, wasm_module_t*);
   ~ScriptInstance();
+
+  void initializeScript(wasm_module_t*);
+  void initializeScriptRaw(wasm_module_t*, wasm_instance_t*);
+  void terminateScript();
 
   // TODO(marceline-cramer) Make observers in ScriptEnvironment for events
   // TODO(marceline-cramer) Define entrypoint classes and their sizes

--- a/core/scripting/instance/WorldScript.h
+++ b/core/scripting/instance/WorldScript.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2021 the Mondradiko contributors.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "core/scripting/instance/ScriptInstance.h"
+
+namespace mondradiko {
+namespace core {
+
+// Forward declarations
+class World;
+
+class WorldScript : public ScriptInstance {
+ public:
+  WorldScript(ScriptEnvironment* scripts, World* world)
+      : ScriptInstance(scripts), world(world) {}
+
+  // Publically-accessible World instance
+  World* const world;
+};
+
+}  // namespace core
+}  // namespace mondradiko

--- a/core/scripting/object/StaticScriptObject.h
+++ b/core/scripting/object/StaticScriptObject.h
@@ -14,20 +14,40 @@ class StaticScriptObject {
   // Defined in generated API linker
   static void linkScriptApi(ScriptEnvironment*, T*);
 
+  StaticScriptObject() : StaticScriptObject(nullptr) {}
+
   StaticScriptObject(ScriptEnvironment* scripts)  // NOLINT (runtime/explicit)
-      : scripts(scripts), _static_symbol(typeid(T).name()) {
-    if (scripts != nullptr &&
-        scripts->storeStaticObject(_static_symbol, this)) {
-      linkScriptApi(scripts, static_cast<T*>(this));
-    }
+      : _host_environment(nullptr), _static_symbol(typeid(T).name()) {
+    linkToEnvironment(scripts);
   }
 
-  ~StaticScriptObject() {
-    if (scripts != nullptr) scripts->removeStaticObject(_static_symbol);
+  ~StaticScriptObject() { linkToEnvironment(nullptr); }
+
+  bool linkToEnvironment(ScriptEnvironment* scripts) {
+    // Remove ourselves from our previous host environment
+    if (_host_environment != nullptr) {
+      _host_environment->removeStaticObject(_static_symbol);
+    }
+
+    // Associate ourselves with the new host environment
+    _host_environment = scripts;
+
+    // If the new host turns out to be nullptr, quit
+    if (_host_environment == nullptr) return false;
+
+    // Otherwise, store ourselves
+    if (!_host_environment->storeStaticObject(_static_symbol, this)) {
+      // If an object of our type was already registered, quit
+      return false;
+    }
+
+    // Link our script API and exit successfully
+    linkScriptApi(_host_environment, static_cast<T*>(this));
+    return true;
   }
 
  private:
-  ScriptEnvironment* const scripts;
+  ScriptEnvironment* _host_environment;
   const char* _static_symbol;
 };
 

--- a/core/world/ScriptEntity.cc
+++ b/core/world/ScriptEntity.cc
@@ -3,10 +3,12 @@
 
 #include "core/world/ScriptEntity.h"
 
+#include "core/components/internal/ScriptComponent.h"
 #include "core/components/scriptable/PointLightComponent.h"
 #include "core/components/scriptable/TransformComponent.h"
 #include "core/scripting/environment/ComponentScriptEnvironment.h"
 #include "core/scripting/instance/ComponentScript.h"
+#include "core/scripting/instance/WorldScript.h"
 #include "core/world/World.h"
 #include "types/containers/string.h"
 
@@ -60,14 +62,14 @@ static wasm_functype_t* methodType_Entity_spawnScriptedChildAt() {
 }
 
 // Helper function
-static wasm_trap_t* spawnChild(ComponentScript* instance,
+static wasm_trap_t* spawnChild(WorldScript* instance,
                                const wasm_val_t& self_arg,
                                EntityId* new_entity) {
   World* world = instance->world;
 
   EntityId self_id = self_arg.of.i32;
   if (!world->registry.valid(self_id)) {
-    return world->scripts.createTrap("Invalid entity ID");
+    return instance->scripts->createTrap("Invalid entity ID");
   }
 
   *new_entity = world->registry.create();
@@ -76,7 +78,37 @@ static wasm_trap_t* spawnChild(ComponentScript* instance,
   return nullptr;
 }
 
-static wasm_trap_t* Entity_spawnChild(ComponentScript* instance,
+// Helper function
+static wasm_trap_t* instantiateScript(WorldScript* instance,
+                                      const wasm_val_t& self_arg,
+                                      const wasm_val_t& script_impl_arg,
+                                      EntityId new_entity) {
+  World* world = instance->world;
+
+  EntityId self_id = self_arg.of.i32;
+  if (!world->registry.valid(self_id)) {
+    return instance->scripts->createTrap("Invalid entity ID");
+  } else if (!world->registry.has<ScriptComponent>(self_id)) {
+    return instance->scripts->createTrap(
+        "Entity does not have ScriptComponent");
+  }
+
+  types::string impl;
+  if (!instance->AS_getString(script_impl_arg.of.i32, &impl)) {
+    return instance->scripts->createTrap("script_impl is not a valid string");
+  }
+
+  auto& component_script = world->registry.get<ScriptComponent>(self_id);
+  auto component_instance = component_script.getInstance();
+  ComponentScriptEnvironment* scripts = &world->scripts;
+
+  scripts->instantiateScript(new_entity, component_instance->getAsset().getId(),
+                             impl);
+
+  return nullptr;
+}
+
+static wasm_trap_t* Entity_spawnChild(WorldScript* instance,
                                       const wasm_val_t args[],
                                       wasm_val_t results[]) {
   EntityId new_entity;
@@ -89,7 +121,7 @@ static wasm_trap_t* Entity_spawnChild(ComponentScript* instance,
   return nullptr;
 }
 
-static wasm_trap_t* Entity_spawnChildAt(ComponentScript* instance,
+static wasm_trap_t* Entity_spawnChildAt(WorldScript* instance,
                                         const wasm_val_t args[],
                                         wasm_val_t results[]) {
   World* world = instance->world;
@@ -108,11 +140,9 @@ static wasm_trap_t* Entity_spawnChildAt(ComponentScript* instance,
   return nullptr;
 }
 
-static wasm_trap_t* Entity_spawnScriptedChild(ComponentScript* instance,
+static wasm_trap_t* Entity_spawnScriptedChild(WorldScript* instance,
                                               const wasm_val_t args[],
                                               wasm_val_t results[]) {
-  World* world = instance->world;
-
   EntityId new_entity;
   wasm_trap_t* trap = spawnChild(instance, args[0], &new_entity);
   if (trap != nullptr) return trap;
@@ -120,19 +150,13 @@ static wasm_trap_t* Entity_spawnScriptedChild(ComponentScript* instance,
   results[0].kind = WASM_I32;
   results[0].of.i32 = new_entity;
 
-  ComponentScriptEnvironment& scripts = world->scripts;
-
-  types::string impl;
-  if (!instance->AS_getString(args[1].of.i32, &impl)) {
-    return scripts.createTrap("script_impl is not a valid string");
-  }
-
-  scripts.instantiateScript(new_entity, instance->getAsset().getId(), impl);
+  trap = instantiateScript(instance, args[0], args[1], new_entity);
+  if (trap != nullptr) return trap;
 
   return nullptr;
 }
 
-static wasm_trap_t* Entity_spawnScriptedChildAt(ComponentScript* instance,
+static wasm_trap_t* Entity_spawnScriptedChildAt(WorldScript* instance,
                                                 const wasm_val_t args[],
                                                 wasm_val_t results[]) {
   World* world = instance->world;
@@ -148,20 +172,14 @@ static wasm_trap_t* Entity_spawnScriptedChildAt(ComponentScript* instance,
   auto ori = glm::quat();
   world->registry.emplace<TransformComponent>(new_entity, pos, ori);
 
-  ComponentScriptEnvironment& scripts = world->scripts;
-
-  types::string impl;
-  if (!instance->AS_getString(args[1].of.i32, &impl)) {
-    return scripts.createTrap("script_impl is not a valid string");
-  }
-
-  scripts.instantiateScript(new_entity, instance->getAsset().getId(), impl);
+  trap = instantiateScript(instance, args[0], args[1], new_entity);
+  if (trap != nullptr) return trap;
 
   return nullptr;
 }
 
 template <class ComponentType>
-static wasm_trap_t* Entity_hasComponent(ComponentScript* instance,
+static wasm_trap_t* Entity_hasComponent(WorldScript* instance,
                                         const wasm_val_t args[],
                                         wasm_val_t results[]) {
   World* world = instance->world;
@@ -183,7 +201,7 @@ static wasm_trap_t* Entity_hasComponent(ComponentScript* instance,
 }
 
 template <class ComponentType>
-static wasm_trap_t* Entity_addComponent(ComponentScript* instance,
+static wasm_trap_t* Entity_addComponent(WorldScript* instance,
                                         const wasm_val_t args[],
                                         wasm_val_t results[]) {
   World* world = instance->world;
@@ -204,7 +222,7 @@ static wasm_trap_t* Entity_addComponent(ComponentScript* instance,
 }
 
 template <class ComponentType>
-static wasm_trap_t* Entity_getComponent(ComponentScript* instance,
+static wasm_trap_t* Entity_getComponent(WorldScript* instance,
                                         const wasm_val_t args[],
                                         wasm_val_t results[]) {
   World* world = instance->world;
@@ -223,7 +241,7 @@ static wasm_trap_t* Entity_getComponent(ComponentScript* instance,
   return nullptr;
 }
 
-using BoundEntityMethod = wasm_trap_t* (*)(ComponentScript*, const wasm_val_t[],
+using BoundEntityMethod = wasm_trap_t* (*)(WorldScript*, const wasm_val_t[],
                                            wasm_val_t[]);
 
 using EntityMethodTypeCallback = wasm_functype_t* (*)();
@@ -232,7 +250,7 @@ template <BoundEntityMethod method>
 wasm_trap_t* entityMethodWrapper(const wasmtime_caller_t* caller, void* env,
                                  const wasm_val_t args[],
                                  wasm_val_t results[]) {
-  ComponentScript* instance = reinterpret_cast<ComponentScript*>(env);
+  WorldScript* instance = reinterpret_cast<WorldScript*>(env);
 
   World* world = instance->world;
 
@@ -268,40 +286,36 @@ wasm_func_t* createEntityMethod(ScriptInstance* instance) {
 }
 
 template <BoundEntityMethod method, EntityMethodTypeCallback type_callback>
-void linkEntityMethod(ComponentScriptEnvironment* scripts, World* world,
-                      const types::string& symbol) {
+void linkEntityMethod(ScriptEnvironment* scripts, const types::string& symbol) {
   ScriptBindingFactory factory = createEntityMethod<method, type_callback>;
   scripts->addBindingFactory(symbol, factory);
 }
 
 // Helper function to link a component API
 template <class ComponentType>
-void linkComponentApi(World* world, const char* symbol) {
-  ComponentScriptEnvironment* scripts = &world->scripts;
+void linkComponentApi(ScriptEnvironment* scripts, const char* symbol) {
   linkEntityMethod<Entity_getComponent<ComponentType>, methodType_Entity>(
-      scripts, world, types::string("Entity_get") + symbol);
+      scripts, types::string("Entity_get") + symbol);
   linkEntityMethod<Entity_hasComponent<ComponentType>, methodType_Entity>(
-      scripts, world, types::string("Entity_has") + symbol);
+      scripts, types::string("Entity_has") + symbol);
   linkEntityMethod<Entity_addComponent<ComponentType>, methodType_Entity>(
-      scripts, world, types::string("Entity_add") + symbol);
+      scripts, types::string("Entity_add") + symbol);
 }
 
-void ScriptEntity::linkScriptApi(World* world) {
-  ComponentScriptEnvironment* scripts = &world->scripts;
-
-  linkEntityMethod<Entity_spawnChild, methodType_Entity>(scripts, world,
+void ScriptEntity::linkScriptApi(ScriptEnvironment* scripts, World* world) {
+  linkEntityMethod<Entity_spawnChild, methodType_Entity>(scripts,
                                                          "Entity_spawnChild");
   linkEntityMethod<Entity_spawnChildAt, methodType_Entity_spawnChildAt>(
-      scripts, world, "Entity_spawnChildAt");
+      scripts, "Entity_spawnChildAt");
   linkEntityMethod<Entity_spawnScriptedChild,
                    methodType_Entity_spawnScriptedChild>(
-      scripts, world, "Entity_spawnScriptedChild");
+      scripts, "Entity_spawnScriptedChild");
   linkEntityMethod<Entity_spawnScriptedChildAt,
                    methodType_Entity_spawnScriptedChildAt>(
-      scripts, world, "Entity_spawnScriptedChildAt");
+      scripts, "Entity_spawnScriptedChildAt");
 
-  linkComponentApi<PointLightComponent>(world, "PointLight");
-  linkComponentApi<TransformComponent>(world, "Transform");
+  linkComponentApi<PointLightComponent>(scripts, "PointLight");
+  linkComponentApi<TransformComponent>(scripts, "Transform");
 }
 
 }  // namespace core

--- a/core/world/ScriptEntity.h
+++ b/core/world/ScriptEntity.h
@@ -7,12 +7,12 @@ namespace mondradiko {
 namespace core {
 
 // Forward declarations
-class ComponentScriptEnvironment;
+class ScriptEnvironment;
 class World;
 
 class ScriptEntity {
  public:
-  static void linkScriptApi(World*);
+  static void linkScriptApi(ScriptEnvironment*, World*);
 };
 
 }  // namespace core

--- a/core/world/World.cc
+++ b/core/world/World.cc
@@ -18,20 +18,14 @@
 #include "core/components/synchronized/RelationshipComponent.h"
 #include "core/components/synchronized/RigidBodyComponent.h"
 #include "core/filesystem/Filesystem.h"
-#include "core/scripting/environment/WorldScriptEnvironment.h"
 #include "log/log.h"
 #include "types/protocol/WorldEvent_generated.h"
 
 namespace mondradiko {
 namespace core {
 
-World::World(AssetPool* asset_pool, Filesystem* fs,
-             WorldScriptEnvironment* world_script_environment)
-    : StaticScriptObject(world_script_environment),
-      asset_pool(asset_pool),
-      fs(fs),
-      scripts(asset_pool, this),
-      physics(this) {
+World::World(AssetPool* asset_pool, Filesystem* fs)
+    : asset_pool(asset_pool), fs(fs), scripts(this), physics(this) {
   log_zone;
 
   asset_pool->initializeAssetType<PrefabAsset>(asset_pool);

--- a/core/world/World.h
+++ b/core/world/World.h
@@ -25,11 +25,10 @@ namespace core {
 
 // Forward declarations
 class Filesystem;
-class WorldScriptEnvironment;
 
 class World : public StaticScriptObject<World> {
  public:
-  World(AssetPool*, Filesystem*, WorldScriptEnvironment*);
+  World(AssetPool*, Filesystem*);
   ~World();
 
   void initializePrefabs();

--- a/lib/include/wasm_headers.h
+++ b/lib/include/wasm_headers.h
@@ -4,4 +4,5 @@
 #pragma once
 
 #include <wasm.h>      // NOLINT
+#include <wasi.h>      // NOLINT
 #include <wasmtime.h>  // NOLINT

--- a/server/server_main.cc
+++ b/server/server_main.cc
@@ -74,7 +74,7 @@ void run(const ServerArgs& args) {
   MeshPass::initDummyAssets(&asset_pool);
 
   WorldScriptEnvironment scripts;
-  World world(&asset_pool, &fs, &scripts);
+  World world(&asset_pool, &fs);
   WorldEventSorter world_event_sorter(&world);
   NetworkServer server(&fs, &world_event_sorter, args.server_ip.c_str(),
                        args.server_port);


### PR DESCRIPTION
World scripts can now be passed in with the `--world-script` argument from either the client or server entrypoint. The world script itself is a WASI-enabled Wasm script that is linked to the component script environment, as well as the `World` static script object. It also can export an `on_update` function that takes the `dt` of every frame.