### PR TITLE
Add bundle exports

### DIFF
--- a/bundler/Bundler.cc
+++ b/bundler/Bundler.cc
@@ -183,6 +183,10 @@ void Bundler::bundle() {
     }
   }
 
+  for (auto& iter : asset_aliases) {
+    bundle_builder->addBundleExport(iter.first, iter.second);
+  }
+
   bundle_builder->buildBundle("registry.bin");
 }
 

--- a/bundler/Bundler.h
+++ b/bundler/Bundler.h
@@ -10,7 +10,6 @@
 #include "converter/AssetBundleBuilder.h"
 #include "converter/BundlerInterface.h"
 #include "converter/ConverterInterface.h"
-#include "converter/PrefabBuilder.h"
 #include "lib/include/toml_headers.h"
 #include "types/assets/SerializedAsset_generated.h"
 #include "types/containers/vector.h"
@@ -38,8 +37,6 @@ class Bundler : public converter::BundlerInterface {
   toml::value manifest;
 
   converter::AssetBundleBuilder* bundle_builder = nullptr;
-  converter::PrefabBuilder* prefab_builder = nullptr;
-
   std::map<std::string, const converter::ConverterInterface*> converters;
   std::map<std::string, assets::AssetId> asset_aliases;
 

--- a/codegen/components/World.toml
+++ b/codegen/components/World.toml
@@ -20,3 +20,11 @@ dependencies = ["Entity"]
     x = "double"
     y = "double"
     z = "double"
+
+  [methods.spawnPrefab]
+  param_list = ["prefab_alias"]
+  brief = "Temporary method for easy prefab spawning."
+  return_class = "Entity"
+
+    [methods.spawnPrefab.params]
+    prefab_alias = "string"

--- a/converter/AssetBundleBuilder.h
+++ b/converter/AssetBundleBuilder.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
 #include <thread>
 #include <unordered_set>
 #include <vector>
@@ -29,6 +30,7 @@ class AssetBundleBuilder {
                                flatbuffers::FlatBufferBuilder*,
                                flatbuffers::Offset<assets::SerializedAsset>);
   assets::AssetResult addInitialPrefab(assets::AssetId);
+  assets::AssetResult addBundleExport(const std::string&, assets::AssetId);
   assets::AssetResult buildBundle(const char*);
 
  private:
@@ -40,6 +42,11 @@ class AssetBundleBuilder {
   struct AssetToSave {
     assets::AssetId id;
     size_t size;
+  };
+
+  struct AssetToExport {
+    std::string alias;
+    assets::AssetId id;
   };
 
   struct LumpToSave {
@@ -58,6 +65,7 @@ class AssetBundleBuilder {
 
   std::vector<LumpToSave*> lumps;
   std::unordered_set<assets::AssetId> used_ids;
+  std::vector<AssetToExport> exported_assets;
   std::vector<assets::AssetId> initial_prefabs;
 
   void launchFinalizer(LumpToSave*);

--- a/converter/CMakeLists.txt
+++ b/converter/CMakeLists.txt
@@ -4,10 +4,10 @@
 set(CONVERTER_SRC
   prefab/BinaryGltfConverter.cc
   prefab/GltfConverter.cc
+  prefab/PrefabBuilder.cc
   prefab/TextGltfConverter.cc
   script/WasmConverter.cc
   AssetBundleBuilder.cc
-  PrefabBuilder.cc
 )
 
 add_library(mondradiko-converter STATIC ${CONVERTER_SRC})

--- a/converter/prefab/PrefabBuilder.h
+++ b/converter/prefab/PrefabBuilder.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
+#include "converter/ConverterInterface.h"
 #include "lib/include/toml_headers.h"
-#include "types/assets/AssetTypes.h"
-#include "types/assets/SerializedAsset_generated.h"
 
 namespace mondradiko {
 namespace converter {
@@ -13,9 +12,15 @@ namespace converter {
 // Forward declarations
 class BundlerInterface;
 
-class PrefabBuilder {
+class PrefabBuilder : public ConverterInterface {
  public:
-  assets::AssetId buildPrefab(BundlerInterface*, const toml::table&);
+  PrefabBuilder(BundlerInterface*);
+
+  // ConverterInterface implementation
+  AssetOffset convert(AssetBuilder*, const toml::table&) const final;
+
+ private:
+  BundlerInterface* bundler;
 };
 
 }  // namespace converter

--- a/core/assets/AssetPool.h
+++ b/core/assets/AssetPool.h
@@ -10,6 +10,7 @@
 #include "core/filesystem/Filesystem.h"
 #include "lib/include/entt_headers.h"
 #include "log/log.h"
+#include "types/containers/string.h"
 #include "types/containers/unordered_map.h"
 #include "types/containers/vector.h"
 
@@ -119,10 +120,31 @@ class AssetPool {
     pool.clear();
   }
 
+  void addAlias(const types::string& alias, AssetId id) {
+    auto iter = aliases.find(alias);
+    if (iter != aliases.end()) {
+      log_err_fmt("Alias '%s' is already taken", alias.c_str());
+      return;
+    }
+
+    aliases.emplace(alias, id);
+  }
+
+  AssetId lookUpAlias(const types::string& alias) {
+    auto iter = aliases.find(alias);
+    if (iter != aliases.end()) {
+      return iter->second;
+    } else {
+      log_err_fmt("Alias '%s' not found", alias.c_str());
+      return NullAsset;
+    }
+  }
+
  private:
   Filesystem* fs;
 
   types::vector<Asset*> templates;
+  types::unordered_map<types::string, AssetId> aliases;
   types::unordered_map<AssetId, Asset*> pool;
 };
 

--- a/core/components/synchronized/RigidBodyComponent.cc
+++ b/core/components/synchronized/RigidBodyComponent.cc
@@ -12,8 +12,6 @@ RigidBodyComponent::RigidBodyComponent(const assets::RigidBodyPrefab* prefab) {
   _data.mutate_mass(prefab->mass());
 }
 
-RigidBodyComponent::~RigidBodyComponent() { _destroy(nullptr); }
-
 WorldTransform RigidBodyComponent::makeWorldTransform() {
   auto transform = _rigid_body->getCenterOfMassTransform();
   auto body_position = transform.getOrigin();
@@ -25,22 +23,6 @@ WorldTransform RigidBodyComponent::makeWorldTransform() {
                         body_orientation.y(), body_orientation.z());
 
   return WorldTransform(position, orientation);
-}
-
-void RigidBodyComponent::_destroy(btDynamicsWorld* dynamics_world) {
-  if (_rigid_body != nullptr) {
-    if (dynamics_world != nullptr) {
-      dynamics_world->removeRigidBody(_rigid_body);
-    }
-
-    delete _rigid_body;
-    _rigid_body = nullptr;
-  }
-
-  if (_motion_state != nullptr) {
-    delete _motion_state;
-    _motion_state = nullptr;
-  }
 }
 
 }  // namespace core

--- a/core/components/synchronized/RigidBodyComponent.h
+++ b/core/components/synchronized/RigidBodyComponent.h
@@ -18,7 +18,6 @@ class RigidBodyComponent
     : public SynchronizedComponent<protocol::RigidBodyComponent> {
  public:
   explicit RigidBodyComponent(const assets::RigidBodyPrefab*);
-  ~RigidBodyComponent();
 
   // TODO(marceline-cramer) Rigid body network sync
 
@@ -30,9 +29,6 @@ class RigidBodyComponent
 
   btRigidBody* _rigid_body = nullptr;
   btMotionState* _motion_state = nullptr;
-
-  // Helper methods
-  void _destroy(btDynamicsWorld*);
 };
 
 }  // namespace core

--- a/core/filesystem/AssetBundle.h
+++ b/core/filesystem/AssetBundle.h
@@ -7,6 +7,7 @@
 
 #include "core/filesystem/AssetLump.h"
 #include "types/assets/AssetTypes.h"
+#include "types/containers/string.h"
 #include "types/containers/unordered_map.h"
 #include "types/containers/vector.h"
 
@@ -21,12 +22,15 @@ class AssetBundle {
   assets::AssetResult loadRegistry(const char*);
 
   void getChecksums(types::vector<assets::LumpHash>&);
+  void getBundleExports(types::unordered_map<types::string, assets::AssetId>*);
   void getInitialPrefabs(types::vector<assets::AssetId>&);
   bool isAssetRegistered(assets::AssetId);
   bool loadAsset(const assets::SerializedAsset**, assets::AssetId);
 
  private:
   std::filesystem::path bundle_root;
+
+  types::unordered_map<types::string, assets::AssetId> bundle_exports;
 
   types::vector<assets::AssetId> initial_prefabs;
 

--- a/core/filesystem/Filesystem.cc
+++ b/core/filesystem/Filesystem.cc
@@ -5,6 +5,7 @@
 
 #include <sstream>
 
+#include "core/assets/AssetPool.h"
 #include "log/log.h"
 
 namespace mondradiko {
@@ -41,6 +42,18 @@ void Filesystem::getChecksums(
     asset_bundle->getChecksums(bundle_checksums);
     local_checksums.insert(local_checksums.end(), bundle_checksums.begin(),
                            bundle_checksums.end());
+  }
+}
+
+void Filesystem::indexExports(AssetPool* asset_pool) {
+  types::unordered_map<types::string, assets::AssetId> exports;
+
+  for (auto asset_bundle : asset_bundles) {
+    asset_bundle->getBundleExports(&exports);
+  }
+
+  for (auto iter : exports) {
+    asset_pool->addAlias(iter.first, iter.second);
   }
 }
 

--- a/core/filesystem/Filesystem.h
+++ b/core/filesystem/Filesystem.h
@@ -14,6 +14,9 @@
 namespace mondradiko {
 namespace core {
 
+// Forward declarations
+class AssetPool;
+
 class Filesystem {
  public:
   Filesystem();
@@ -21,6 +24,7 @@ class Filesystem {
 
   bool loadAssetBundle(const std::filesystem::path&);
   void getChecksums(types::vector<assets::LumpHash>&);
+  void indexExports(AssetPool*);
   void getInitialPrefabs(types::vector<assets::AssetId>&);
   bool loadAsset(const assets::SerializedAsset**, AssetId);
 

--- a/core/physics/Physics.h
+++ b/core/physics/Physics.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/world/Entity.h"
 #include "lib/include/bullet_headers.h"
 
 namespace mondradiko {
@@ -28,6 +29,9 @@ class Physics {
   btDiscreteDynamicsWorld* dynamics_world = nullptr;
 
   btCollisionShape* default_shape = nullptr;
+
+  // Observer to clean up RigidBodyComponents
+  static void onRigidBodyComponentDestroy(EntityRegistry&, EntityId);
 };
 
 }  // namespace core

--- a/core/scripting/environment/ComponentScriptEnvironment.cc
+++ b/core/scripting/environment/ComponentScriptEnvironment.cc
@@ -77,6 +77,8 @@ void ComponentScriptEnvironment::instantiateScript(EntityId entity,
   auto& component = registry->emplace<ScriptComponent>(entity);
   component._script_impl = impl;
   component._script_instance = instance;
+
+  instance->construct();
 }
 
 void ComponentScriptEnvironment::onScriptComponentDestroy(

--- a/core/scripting/environment/ComponentScriptEnvironment.h
+++ b/core/scripting/environment/ComponentScriptEnvironment.h
@@ -33,12 +33,12 @@ class ComponentScriptEnvironment : public ScriptEnvironment {
    */
   void instantiateScript(EntityId, AssetId, const types::string&);
 
-  // Observer to clean up ScriptComponents
-  static void onScriptComponentDestroy(EntityRegistry&, EntityId);
-
  private:
   AssetPool* const asset_pool;
   World* const world;
+
+  // Observer to clean up ScriptComponents
+  static void onScriptComponentDestroy(EntityRegistry&, EntityId);
 };
 
 }  // namespace core

--- a/core/scripting/instance/ComponentScript.cc
+++ b/core/scripting/instance/ComponentScript.cc
@@ -20,7 +20,11 @@ ComponentScript::ComponentScript(ComponentScriptEnvironment* scripts,
       _impl(impl),
       _self_id(self_id) {
   initializeScript(asset->getModule());
+}
 
+ComponentScript::~ComponentScript() { AS_unpin(_this_ptr); }
+
+void ComponentScript::construct() {
   wasm_val_t self_arg;
   self_arg.kind = WASM_I32;
   self_arg.of.i32 = _self_id;
@@ -39,8 +43,6 @@ ComponentScript::ComponentScript(ComponentScriptEnvironment* scripts,
     log_wrn_fmt("Component script %s does not export update", _impl.c_str());
   }
 }
-
-ComponentScript::~ComponentScript() { AS_unpin(_this_ptr); }
 
 void ComponentScript::update(double dt) {
   if (_update == nullptr) return;

--- a/core/scripting/instance/ComponentScript.h
+++ b/core/scripting/instance/ComponentScript.h
@@ -25,6 +25,7 @@ class ComponentScript : public WorldScript {
 
   const AssetHandle<ScriptAsset>& getAsset() { return _asset; }
 
+  void construct();
   void update(double);
 
   // TODO(marceline-cramer) Actually update instance data
@@ -34,8 +35,8 @@ class ComponentScript : public WorldScript {
   AssetHandle<ScriptAsset> _asset;
   types::string _impl;
   EntityId _self_id;
-  uint32_t _this_ptr;
 
+  uint32_t _this_ptr = 0;
   wasm_func_t* _update = nullptr;
 };
 

--- a/core/world/World.cc
+++ b/core/world/World.cc
@@ -29,6 +29,7 @@ World::World(AssetPool* asset_pool, Filesystem* fs)
   log_zone;
 
   asset_pool->initializeAssetType<PrefabAsset>(asset_pool);
+  fs->indexExports(asset_pool);
 
   registry.on_construct<TransformComponent>()
       .connect<&onTransformAuthorityConstruct>();

--- a/core/world/World.cc
+++ b/core/world/World.cc
@@ -18,6 +18,7 @@
 #include "core/components/synchronized/RelationshipComponent.h"
 #include "core/components/synchronized/RigidBodyComponent.h"
 #include "core/filesystem/Filesystem.h"
+#include "core/scripting/instance/ScriptInstance.h"
 #include "log/log.h"
 #include "types/protocol/WorldEvent_generated.h"
 
@@ -332,6 +333,27 @@ wasm_trap_t* World::spawnEntityAt(ScriptInstance*, const wasm_val_t args[],
   registry.emplace<TransformComponent>(
       new_entity, glm::vec3(args[0].of.f64, args[1].of.f64, args[2].of.f64),
       glm::quat());
+
+  results[0].kind = WASM_I32;
+  results[0].of.i32 = new_entity;
+  return nullptr;
+}
+
+wasm_trap_t* World::spawnPrefab(ScriptInstance* instance,
+                                const wasm_val_t args[], wasm_val_t results[]) {
+  types::string prefab_alias;
+  if (!instance->AS_getString(args[0].of.i32, &prefab_alias)) {
+    return scripts.createTrap("Failed to get script_alias");
+  }
+
+  AssetId prefab_id = asset_pool->lookUpAlias(prefab_alias);
+  auto prefab_asset = asset_pool->load<PrefabAsset>(prefab_id);
+
+  if (!prefab_asset) {
+    return scripts.createTrap("Failed to load script_alias");
+  }
+
+  EntityId new_entity = prefab_asset->instantiate(this);
 
   results[0].kind = WASM_I32;
   results[0].of.i32 = new_entity;

--- a/core/world/World.h
+++ b/core/world/World.h
@@ -70,6 +70,7 @@ class World : public StaticScriptObject<World> {
   //
   wasm_trap_t* spawnEntity(ScriptInstance*, const wasm_val_t[], wasm_val_t[]);
   wasm_trap_t* spawnEntityAt(ScriptInstance*, const wasm_val_t[], wasm_val_t[]);
+  wasm_trap_t* spawnPrefab(ScriptInstance*, const wasm_val_t[], wasm_val_t[]);
 
   // TODO(marceline-cramer) Blech, restore World privacy
   // Move event callbacks to private

--- a/server/server_main.cc
+++ b/server/server_main.cc
@@ -131,9 +131,9 @@ void run(const ServerArgs& args) {
     double dt = std::chrono::duration<double, std::chrono::seconds::period>(
                     frame_start - last_frame)
                     .count();
+    last_frame = frame_start;
     if (scripts) scripts->update(dt);
     if (!world.update(dt)) break;
-    last_frame = frame_start;
   }
 }
 

--- a/types/assets/Registry.fbs
+++ b/types/assets/Registry.fbs
@@ -10,6 +10,11 @@ struct AssetEntry {
   size:uint32;
 }
 
+table BundleExport {
+  alias:string;
+  id:uint32;
+}
+
 table LumpEntry {
   checksum:LumpHash;
   file_size:uint64;
@@ -23,6 +28,7 @@ table Registry {
   minor_version:int;
   patch_version:int;
   initial_prefabs:[uint32];
+  exports:[BundleExport];
   lumps:[LumpEntry];
 }
 


### PR DESCRIPTION
- Makes `PrefabBuilder` a type of `ConverterInterface`
- Moves `[[prefabs]]` into a type of `[[assets]]` using `type = "shape"`
- Adds "bundle exports" to registries, which are string-indexed asset IDs
- Adds `World.spawnPrefab()` script binding
- Fixes lazy `RigidBodyComponent` de-initing by using `EntityRegistry` observer in `Physics`